### PR TITLE
modified gitignore to keep devs useful files locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # testing
 /coverage
+/src/demo
 
 # misc
 .DS_Store
@@ -16,6 +17,10 @@
 .env.development.local
 .env.test.local
 .env.production.local
+usage.py
+
+# PyCharm
+.idea/
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Added  `usage.py` file as well as `/src/demo` and `.idea/` folders to the `.gitignore` file as they prove handy for local testing, especially since `index.py` doesn't show callback exceptions.