### PR TITLE
Add status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dash Bio
 
+[![CircleCI](https://circleci.com/gh/plotly/dash-bio/tree/master.svg?style=svg&circle-token=514e349727fb30e6b85bdaa8269aef3b3e1d320e)](https://circleci.com/gh/plotly/dash-bio/tree/master)
+
 Dash components for bioinformatics
 
 ## Progress


### PR DESCRIPTION
Closes #93 

I followed these [instructions](https://circleci.com/docs/2.0/status-badges/) to create a badge that displays our build status (passed or failed) in the README.

Maybe I should have left the branch value as 'default' (I chose 'master'), so that https://circleci.com/gh/plotly/dash-bio/tree/master would simply read https://circleci.com/gh/plotly/dash-bio ...

The next step is to go through `.circleci/config.yml` so that we decide what we are running exactly and in which environments exactly.

/cc @Bachibouzouk @shammamah @VeraZab 