### PR TITLE
Let example/demo apps run as standalone apps.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,7 +15,7 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook="import sys; sys.path.append('./tests/dashbio_demos')"
 
 # Use multiple processes to speed up Pylint.
 jobs=1

--- a/index.py
+++ b/index.py
@@ -94,11 +94,6 @@ def demo_app_header_colors(name):
         return {}
 
 
-def demo_app_github_url(name):
-    """ Returns the link with the code for the demo app. """ 
-    return name
-
-
 def demo_app_link_id(name):
     """Returns the value of the id of the dcc.Link related to the demo app. """
     return 'app-link-id-{}'.format(name.replace("_", "-"))
@@ -145,7 +140,7 @@ def display_app(pathname):
                         children=app_page_layout(
                             apps[app_name].layout(),
                             app_title=demo_app_name(app_name),
-                            app_github_url=demo_app_github_url(app_name),
+                            app_name=app_name,
                             **demo_app_header_colors(app_name)
                         ))
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ biopython
 colour==0.1.5
 cython>=0.19
 dash==0.35.2
-dash_bio==0.0.1
+dash-bio==0.0.2
 dash-core-components==0.36.1
 dash-html-components==0.13.2
 dash-renderer==0.15.0

--- a/tests/dashbio_demos/app_alignment_viewer.py
+++ b/tests/dashbio_demos/app_alignment_viewer.py
@@ -250,4 +250,5 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)
+

--- a/tests/dashbio_demos/app_alignment_viewer.py
+++ b/tests/dashbio_demos/app_alignment_viewer.py
@@ -246,3 +246,8 @@ def callbacks(app):
     )
     def update_chart(input_data):
         return input_data
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_alignment_viewer.py
+++ b/tests/dashbio_demos/app_alignment_viewer.py
@@ -251,4 +251,3 @@ def callbacks(app):
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
     run_standalone_app(layout, callbacks, header_colors, __file__)
-

--- a/tests/dashbio_demos/app_circos.py
+++ b/tests/dashbio_demos/app_circos.py
@@ -1485,4 +1485,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_circos.py
+++ b/tests/dashbio_demos/app_circos.py
@@ -1481,3 +1481,8 @@ def callbacks(app):
     )
     def event_data_custom(_, event_datum):
         return str(event_datum)
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -727,3 +727,8 @@ def callbacks(app):
         if contents is not None:
             return None
         return current
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -731,4 +731,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_ideogram.py
+++ b/tests/dashbio_demos/app_ideogram.py
@@ -858,4 +858,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_ideogram.py
+++ b/tests/dashbio_demos/app_ideogram.py
@@ -854,3 +854,8 @@ def callbacks(app):
             data = data.split("<br>")
             data = data[0] + " " + data[1]
         return data
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -140,4 +140,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -136,3 +136,8 @@ def callbacks(app):
             genomewideline_value=float(slider_genome),
             suggestiveline_value=float(slider_indic),
         )
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_molecule3d.py
+++ b/tests/dashbio_demos/app_molecule3d.py
@@ -356,3 +356,8 @@ def callbacks(app):
     )
     def change_bgopacity(opacity):
         return opacity
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_molecule3d.py
+++ b/tests/dashbio_demos/app_molecule3d.py
@@ -360,4 +360,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_needle_plot.py
+++ b/tests/dashbio_demos/app_needle_plot.py
@@ -1016,4 +1016,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_needle_plot.py
+++ b/tests/dashbio_demos/app_needle_plot.py
@@ -1012,3 +1012,8 @@ def callbacks(app):
 
         domain_sty['domainColor'] = small_domains_colors
         return domain_sty
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_oncoprint.py
+++ b/tests/dashbio_demos/app_oncoprint.py
@@ -401,4 +401,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_oncoprint.py
+++ b/tests/dashbio_demos/app_oncoprint.py
@@ -397,3 +397,8 @@ def callbacks(app):
     )
     def update_colorscale(data):
         return data[COLORSCALE_KEY]
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_sequence_viewer.py
+++ b/tests/dashbio_demos/app_sequence_viewer.py
@@ -997,4 +997,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_sequence_viewer.py
+++ b/tests/dashbio_demos/app_sequence_viewer.py
@@ -993,3 +993,8 @@ def callbacks(app):
             test.append("Sequence: %s" % sel['sequence'])
             test.append(html.Br())
         return test
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_speck.py
+++ b/tests/dashbio_demos/app_speck.py
@@ -142,4 +142,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_speck.py
+++ b/tests/dashbio_demos/app_speck.py
@@ -138,3 +138,8 @@ def callbacks(app):
     )
     def preset_callback(preset_val):
         return preset_val
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/app_volcano_plot.py
+++ b/tests/dashbio_demos/app_volcano_plot.py
@@ -267,4 +267,4 @@ def callbacks(app):
 
 if __name__ == '__main__':
     from utils.app_standalone import run_standalone_app
-    run_standalone_app(layout, callbacks)
+    run_standalone_app(layout, callbacks, header_colors, __file__)

--- a/tests/dashbio_demos/app_volcano_plot.py
+++ b/tests/dashbio_demos/app_volcano_plot.py
@@ -263,3 +263,8 @@ def callbacks(app):
             idx = x > float(u_lim)
             number = len(x[idx])
         return str(number)
+
+
+if __name__ == '__main__':
+    from utils.app_standalone import run_standalone_app
+    run_standalone_app(layout, callbacks)

--- a/tests/dashbio_demos/utils/app_standalone.py
+++ b/tests/dashbio_demos/utils/app_standalone.py
@@ -15,13 +15,13 @@ def run_standalone_app(
     # Handle callback to component with id "fullband-switch"
     app.config['suppress_callback_exceptions'] = True
 
-    # Get all information from filename 
+    # Get all information from filename
     app_name = os.path.basename(filename).replace(
         '.py', '').replace(
             'app_', '')
 
     app_title = "Dash {}".format(app_name.replace('_', ' ').title())
-    
+
     # Assign layout
     app.layout = app_page_layout(
         page_layout=layout(),

--- a/tests/dashbio_demos/utils/app_standalone.py
+++ b/tests/dashbio_demos/utils/app_standalone.py
@@ -1,15 +1,35 @@
 import dash
+import os
 from .app_wrapper import app_page_layout
 
 
-def run_standalone_app(layout, callbacks, port=8050, debug=True):
+def run_standalone_app(
+        layout,
+        callbacks,
+        header_colors,
+        filename,
+        port=8050, debug=True):
     """Run demo app (tests/dashbio_demos/app_*.py) as standalone app."""
     app = dash.Dash(__name__, assets_folder='assets/')
     app.scripts.config.serve_locally = True
     # Handle callback to component with id "fullband-switch"
     app.config['suppress_callback_exceptions'] = True
+
+    # Get all information from filename 
+    app_name = os.path.basename(filename).replace(
+        '.py', '').replace(
+            'app_', '')
+
+    app_title = "Dash {}".format(app_name.replace('_', ' ').title())
+    
     # Assign layout
-    app.layout = app_page_layout(layout())
+    app.layout = app_page_layout(
+        page_layout=layout(),
+        app_title=app_title,
+        app_name=app_name,
+        **header_colors()
+    )
+
     # Register all callbacks
     callbacks(app)
     app.run_server(debug=debug, port=port)

--- a/tests/dashbio_demos/utils/app_standalone.py
+++ b/tests/dashbio_demos/utils/app_standalone.py
@@ -1,0 +1,15 @@
+import dash
+from .app_wrapper import app_page_layout
+
+
+def run_standalone_app(layout, callbacks, port=8050, debug=True):
+    """Run demo app (tests/dashbio_demos/app_*.py) as standalone app."""
+    app = dash.Dash(__name__, assets_folder='assets/')
+    app.scripts.config.serve_locally = True
+    # Handle callback to component with id "fullband-switch"
+    app.config['suppress_callback_exceptions'] = True
+    # Assign layout
+    app.layout = app_page_layout(layout())
+    # Register all callbacks
+    callbacks(app)
+    app.run_server(debug=debug, port=port)

--- a/tests/dashbio_demos/utils/app_wrapper.py
+++ b/tests/dashbio_demos/utils/app_wrapper.py
@@ -5,8 +5,9 @@ import base64
 
 def app_page_layout(page_layout,
                     app_title="Dash Bio App",
-                    app_github_url="",
+                    app_name="",
                     light_logo=True,
+                    standalone=False,
                     bg_color="#506784",
                     font_color="#F3F6FA"):
     return html.Div(
@@ -47,8 +48,11 @@ def app_page_layout(page_layout,
                                 )
                             )
                         ],
-                        href="http://github.com/plotly/dash-bio/"
-                             "blob/master/tests/dashbio_demos/app_{}.py".format(app_github_url)
+                        href="/" if standalone else
+                        "http://github.com/plotly/dash-bio/"
+                        "blob/master/tests/dashbio_demos/app_{}.py".format(
+                            app_name
+                        )
                     )
                 ],
                 style={

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
+--extra-index-url https://test.pypi.org/simple/
+
 # Packages needed to run the tests.
 # Switch into a virtual environment
 # pip install -r requirements.txt
@@ -6,6 +8,7 @@ chromedriver-binary==2.45.0
 colour==0.1.5
 cython>=0.19
 dash==0.35.2
+dash-bio==0.0.2
 dash-core-components==0.36.1
 dash-html-components==0.13.2
 dash-renderer==0.15.0


### PR DESCRIPTION
Lays the ground for #133.

With this PR, it is still possible to run `python index.py` from the root of the repo, but now also possible to run `python tests/dashbio_demos/app_ideogram.py`.

What's left to do:

- [x]  I have run `pip install -i https://test.pypi.org/simple/ dash-bio` in my (activated) virtualenv, but I'm not sure about the syntax to add it to `tests/requirements.txt`...

- [x]  Read again something like https://chrisyeh96.github.io/2017/08/08/definitive-guide-python-imports.html because imports are of different kinds in these changesets and I'm confused...

- [ ]  Add the same `if __name__ == '__main__':` block to all other example apps.
