### PR TITLE
Make logo link back to portal.

### DIFF
--- a/tests/dashbio_demos/utils/app_wrapper.py
+++ b/tests/dashbio_demos/utils/app_wrapper.py
@@ -27,9 +27,7 @@ def app_page_layout(page_layout,
                                 ).decode()
                             )
                         ),
-                        href="/dash-{}".format(
-                            app_name.replace('_', '-')
-                        ) if standalone else "/dash-bio"
+                        href="/Portal" if standalone else "/dash-bio"
                     ),
                     html.H2(
                         app_title


### PR DESCRIPTION
Instead of directing to the same page (as is the case currently), the logo should serve as a "back" button. 