### PR TITLE
Redirect to portal htmla

### DIFF
--- a/tests/dashbio_demos/utils/app_wrapper.py
+++ b/tests/dashbio_demos/utils/app_wrapper.py
@@ -17,7 +17,7 @@ def app_page_layout(page_layout,
             html.Div(
                 id='app-page-header',
                 children=[
-                    dcc.Link(
+                    html.A(
                         html.Img(
                             src='data:image/png;base64,{}'.format(
                                 base64.b64encode(

--- a/tests/dashbio_demos/utils/app_wrapper.py
+++ b/tests/dashbio_demos/utils/app_wrapper.py
@@ -18,15 +18,16 @@ def app_page_layout(page_layout,
                 id='app-page-header',
                 children=[
                     html.A(
-                        html.Img(
-                            src='data:image/png;base64,{}'.format(
-                                base64.b64encode(
-                                    open(
-                                        './assets/dashbio_logo_transparent.png', 'rb'
-                                    ).read()
-                                ).decode()
-                            )
-                        ),
+                        id='dashbio-logo', children=[
+                            html.Img(
+                                src='data:image/png;base64,{}'.format(
+                                    base64.b64encode(
+                                        open(
+                                            './assets/dashbio_logo_transparent.png', 'rb'
+                                        ).read()
+                                    ).decode()
+                                )
+                            )],
                         href="/Portal" if standalone else "/dash-bio"
                     ),
                     html.H2(


### PR DESCRIPTION
## Description of changes 
Change the Dash Bio logo at the top to refresh the page (with `html.A`) instead of the current `dcc.Link`, which doesn't reload the page when the location is changed. 

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


