### PR TITLE
Add generic test for the subprops

### DIFF
--- a/tests/test_common_features.py
+++ b/tests/test_common_features.py
@@ -1,10 +1,11 @@
 import functools
+import json
 from importlib import import_module
 from pytest_dash.utils import (
     import_app,
     wait_for_element_by_id,
     wait_for_text_to_equal,
-    wait_for_element_by_css_selector,git
+    wait_for_element_by_css_selector
 )
 import dash
 from dash.dependencies import Input, Output, State

--- a/tests/test_common_features.py
+++ b/tests/test_common_features.py
@@ -4,7 +4,7 @@ from pytest_dash.utils import (
     import_app,
     wait_for_element_by_id,
     wait_for_text_to_equal,
-    wait_for_element_by_css_selector,
+    wait_for_element_by_css_selector,git
 )
 import dash
 from dash.dependencies import Input, Output, State
@@ -173,3 +173,67 @@ def template_test_component_single_prop(
     btn = wait_for_element_by_css_selector(selenium, '#test-{}-btn'.format(app_name))
     btn.click()
     wait_for_text_to_equal(selenium, '#test-{}-assert-value-div'.format(app_name), 'PASSED')
+
+
+def generate_assert_callback_subprop(subprop, subprop_type):
+    """Callback generation to test props which are within a dict structure.
+     {
+        prop: {
+            subprop1: val1,
+            subprop2: val2,
+            ...
+            subpropN: valN
+        }
+    :param subprop: (string) name of the subprop
+    :param subprop_type: ()
+    :return: a callback function with will compare the value of the subprop passed to the
+
+    """
+
+    def assert_callback_subprop(p_value, nclicks, input_value):
+        """
+        Perform a comparison between the changed value of a component's subprop and
+        the value which has initiated the change of the subprop of the component via the
+        update_component callback of the simple_app
+        :param p_value: (string) changed value of the component's subprop
+        :param nclicks: (int) html.Button 'n_clicks' Input of the simple_app.layout
+        :param input_value: (string) value of the '...-prop-value-input' dcc.Input which served as
+        the new value of the component prop in the update_component callback of the simple_app
+        :return: a string which will modify the '...-assert-value-div' of the simple_app.layout
+        """
+
+        answer = 'FAILED'
+        if nclicks is not None:
+            input_value = json.loads(input_value)
+            if PROP_TYPES[subprop_type](input_value[subprop]) \
+                    == PROP_TYPES[subprop_type](p_value[subprop]):
+                answer = 'PASSED'
+        return answer
+
+    return assert_callback_subprop
+
+
+def generate_subprop_test(
+        dash_threaded,
+        selenium,
+        app_name,
+        app_test_prop_callback,
+        prop,
+        subprop,
+        subprop_type,
+        subprop_val,
+        **kwargs
+):
+    """Create a test for a prop within a dict."""
+    template_test_component_single_prop(
+        dash_threaded,
+        selenium,
+        app_name,
+        generate_assert_callback_subprop(subprop, subprop_type),
+        app_test_prop_callback,
+        prop,
+        '{"%s": %s}' % (subprop, subprop_val),
+        prop_type='dict',
+        component_base=COMPONENT_REACT_BASE,
+        **kwargs
+    )


### PR DESCRIPTION
## About 
If a prop is a dict which contains "subprops", in order to test those one has to use a callback on the prop with a dict containing the subprop's key and value one would like to test. This testing can be made generic

## Known problems with subprops

if there are default values defined in the `defaultProps` of the .react.js file, they are not accessible through `dash.dependencies.Input` or `dash.dependencies.State` 

```
COMPONENT.propTypes = {
     givenProp: PropTypes.shape({
          subprop1: PropTypes.string,
          subprop2: PropTypes.int,
     })
};

COMPONENT.defaultProps = {
      givenProp: {
           subprop1: "a string",
           subprop2: 12
      }
};
```

If one define a callback like this one
```
@app.callback(
        Output(), # not relevant for the example
        [Input()], # not relevant fot the example
        [State('COMPONENT', 'givenProp')]
):
def do_something(_, prop):
    # here 'prop' will by default be equal to None instead of {subprop1: "a_string", subprop2: 12}
```

This is probably due to the nested props. Also if one try to assign a dict with `subprop3` as a key to `givenProp` via a callback, it doesn't generate a `dash.exceptions.NonExistentPropException`.

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)

