### PR TITLE
Upgrade pip before installing requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
                 name: Install requirements
                 command: |
                     . venv/bin/activate
+                    pip install --upgrade pip
                     pip install -r tests/requirements.txt --quiet
 
             - save_cache:
@@ -73,6 +74,7 @@ jobs:
                 name: Run Integration Tests
                 command: |
                     . venv/bin/activate
+                    pip install --upgrade pip
                     pip install -r tests/requirements.txt
                     pytest --driver chrome tests --ignore tests/test_skeleton.py
 


### PR DESCRIPTION
Hello,

I thought we could add this command (that I personally run locally) to spare the following warnings on Circle CI:

![pip_warning_1](https://user-images.githubusercontent.com/2227806/52959628-eb75fd00-3396-11e9-9cfa-5280c187d3b9.png)
![pip_warning_2](https://user-images.githubusercontent.com/2227806/52959630-edd85700-3396-11e9-9c9e-8569291de14c.png)
