### PR TITLE
Add naming conventions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ before being compiled into Python components that are in the
 `dash_bio/component_factory/` and must be imported in
 `dash_bio/__init__.py`.
 
+###### Naming components
+Components, regardless of whether they are written using React or
+Python, need to be named in upper camel case. This is incredibly
+important due to the amount of parsing we perform in our testing suite
+and app deployments.
+
 ##### Demo applications 
 Instead of creating standalone Dash apps for each component, there is a file
 structure in place to create a main "gallery" page that contains links to each


### PR DESCRIPTION
## About
Addresses #175

## Description of changes 
Specify that upper camel case should be used to name React and Python components.

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


