### PR TITLE
Reorder function arguments in boilerplate code.

### DIFF
--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -77,9 +77,9 @@ def COMPONENTNAME_props_callback(
     """This function is the code of a callback which is triggered by
     the button on the simple app used in the test.
     :param nclicks (int): The n_clicks value of the button in the
-                          simple app
+                          simple app.
     :param prop_name (string): The name of the property that is to be
-                               modified
+                               modified.
     :param prop_value (string): The value that is to be assigned to the
                                 prop defined by prop_name.
     :prop_type (string): One of the predefined types in PROP_TYPES.
@@ -117,9 +117,9 @@ def test_PROPNAME(dash_threaded):
         """Determine the pass/fail status of this test.
 
         :param (int) nclicks: The number of clicks on the button in the
-                              simple test app (not used here)
+                              simple test app (not used here).
         :param (string) component_PROPNAME: The value of PROPNAME for the
-                                            component after it is set
+                                            component after it is set.
         :param (string) input_PROPNAME: The value of PROPNAME that is sent
                                         to the component.
 

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -116,11 +116,11 @@ def test_PROPNAME(dash_threaded):
     ):
         """Determine the pass/fail status of this test.
 
-        :param (int) nclicks: The number of clicks on the button in the
+        :param nclicks (int): The n_clicks value of the button in the
                               simple test app (not used here).
-        :param (string) component_PROPNAME: The value of PROPNAME for the
+        :param component_PROPNAME (string): The value of PROPNAME for the
                                             component after it is set.
-        :param (string) input_PROPNAME: The value of PROPNAME that is sent
+        :param input_PROPNAME (string): The value of PROPNAME that is sent
                                         to the component.
 
         :return (string): 'PASSED' for a test that passed, or 'FAILED'

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -110,16 +110,16 @@ def test_PROPNAME(dash_threaded):
     """Test that some prop updates correctly when changed."""
 
     def assert_callback(
-            component_PROPNAME,
             nclicks,
+            component_PROPNAME,
             input_PROPNAME
     ):
         """Determine the pass/fail status of this test.
 
-        :param (string) component_PROPNAME: The value of PROPNAME for the
-                                            component after it is set
         :param (int) nclicks: The number of clicks on the button in the
                               simple test app (not used here)
+        :param (string) component_PROPNAME: The value of PROPNAME for the
+                                            component after it is set
         :param (string) input_PROPNAME: The value of PROPNAME that is sent
                                         to the component.
 


### PR DESCRIPTION
## About
As per our February 19 discussion, we might as well order arguments of the `assert_callback()` function as nclicks, prop name, ... to match the order suggested in the `COMPONENTNAME_props_callback()` function, declared before.

## Description of changes
This change is not functional, since this code never runs. It's just easier on the brain to read "nclicks, prop name, ..." and then again "nclicks, prop name, ..." (rather than "prop name, niclicks, ..." on the second time).

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)