### PR TITLE
Add explicit wait time before assessing existence of elements in tests

### DIFF
--- a/tests/test_ideogram.py
+++ b/tests/test_ideogram.py
@@ -214,6 +214,7 @@ def test_ploidy(dash_threaded):
 
     driver = dash_threaded.driver
 
+    driver.implicitly_wait(1)
     # assert 22 chromosomes + X and Y chromosomes
     num_chromosoms = len(driver.find_elements_by_class_name('chromosome'))
     assert num_chromosoms == 24
@@ -222,6 +223,7 @@ def test_ploidy(dash_threaded):
     btn = wait_for_element_by_css_selector(driver, '#test-{}-btn'.format(APP_NAME))
     btn.click()
 
+    driver.implicitly_wait(1)
     # assert doubling of the 22 chromosomes + X and Y chromosomes
     num_chromosoms = len(driver.find_elements_by_class_name('chromosome'))
     assert num_chromosoms == 46
@@ -258,6 +260,7 @@ def test_chromosomes(dash_threaded):
     btn = wait_for_element_by_css_selector(driver, '#test-{}-btn'.format(APP_NAME))
     btn.click()
 
+    driver.implicitly_wait(1)
     # assert the set of chromosomes contains 3 chromosomes
     num_chromosoms = len(driver.find_elements_by_class_name('chromosome'))
     assert num_chromosoms == 3
@@ -294,6 +297,7 @@ def test_chromosomes_wrong_input(dash_threaded):
     btn = wait_for_element_by_css_selector(driver, '#test-{}-btn'.format(APP_NAME))
     btn.click()
 
+    driver.implicitly_wait(1)
     # assert the set of chromosomes contains 2 chromosomes
     num_chromosoms = len(driver.find_elements_by_class_name('chromosome'))
     assert num_chromosoms == 2
@@ -422,6 +426,7 @@ def test_show_chromosome_labels(dash_threaded):
     btn = wait_for_element_by_css_selector(driver, '#test-{}-btn'.format(APP_NAME))
     btn.click()
 
+    driver.implicitly_wait(1)
     # assert the presence of chromosomes' labels
     labels = driver.find_elements_by_class_name('chrLabel')
     assert len(labels) != 0


### PR DESCRIPTION
## About 
Fix to prevent the ideogram tests to fail due to time loading the components

## Description of changes 
Add explicit waiting time for now so the test pass

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


