### PR TITLE
Speck setprops fix

### DIFF
--- a/dash_bio/package.json
+++ b/dash_bio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.8-rc11",
+  "version": "0.0.8-rc12",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.8-rc11",
+  "version": "0.0.8-rc12",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ biopython
 colour==0.1.5
 cython>=0.19
 dash==0.37.0
-dash-bio==0.0.8rc11
+dash-bio==0.0.8rc12
 dash-core-components==0.43.1
 dash-daq==0.1.4
 dash-html-components==0.13.5

--- a/src/lib/components/Speck.react.js
+++ b/src/lib/components/Speck.react.js
@@ -93,12 +93,11 @@ export default class Speck extends Component {
                     data[propertyName] !== nextProps.data[propertyName]
             )
         ) {
-            if(this.props.setProps) {
+            if (this.props.setProps) {
                 this.props.setProps({
                     data: nextProps.data,
                 });
-            }
-            else {
+            } else {
                 this.props.data = nextProps.data;
             }
             needsUpdate = true;
@@ -110,12 +109,11 @@ export default class Speck extends Component {
                 view,
                 speckPresetViews[nextProps.presetView]
             );
-            if(this.props.setProps) {
+            if (this.props.setProps) {
                 this.props.setProps({
                     view: v,
                 });
-            }
-            else {
+            } else {
                 this.props.view = v;
             }
 
@@ -131,12 +129,11 @@ export default class Speck extends Component {
             )
         ) {
             const v = Object.assign(view, nextProps.view);
-            if(this.props.setProps) {
+            if (this.props.setProps) {
                 this.props.setProps({
                     view: v,
                 });
-            }
-            else {
+            } else {
                 this.props.view = v;
             }
 

--- a/src/lib/components/Speck.react.js
+++ b/src/lib/components/Speck.react.js
@@ -22,7 +22,7 @@ export default class Speck extends Component {
         speckSystem.calculateBonds(system);
 
         const renderer = this.state.renderer;
-        const view = this.props.view;
+        const view = Object.assign(speckView.new(), this.props.view);
 
         renderer.setSystem(system, view);
 
@@ -42,6 +42,9 @@ export default class Speck extends Component {
                     refreshView: false,
                 });
             }
+
+            // fill in any missing view properties
+            this.props.view = Object.assign(speckView.new(), this.props.view);
             this.state.renderer.render(this.props.view);
         }
         requestAnimationFrame(this.loop);
@@ -90,10 +93,14 @@ export default class Speck extends Component {
                     data[propertyName] !== nextProps.data[propertyName]
             )
         ) {
-            this.props.setProps({
-                data: nextProps.data,
-            });
-
+            if(this.props.setProps) {
+                this.props.setProps({
+                    data: nextProps.data,
+                });
+            }
+            else {
+                this.props.data = nextProps.data;
+            }
             needsUpdate = true;
         }
 
@@ -103,9 +110,14 @@ export default class Speck extends Component {
                 view,
                 speckPresetViews[nextProps.presetView]
             );
-            this.props.setProps({
-                view: v,
-            });
+            if(this.props.setProps) {
+                this.props.setProps({
+                    view: v,
+                });
+            }
+            else {
+                this.props.view = v;
+            }
 
             needsUpdate = true;
         }
@@ -119,9 +131,14 @@ export default class Speck extends Component {
             )
         ) {
             const v = Object.assign(view, nextProps.view);
-            this.props.setProps({
-                view: v,
-            });
+            if(this.props.setProps) {
+                this.props.setProps({
+                    view: v,
+                });
+            }
+            else {
+                this.props.view = v;
+            }
 
             needsUpdate = true;
         }

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,7 +8,7 @@ chromedriver-binary==2.45.0
 colour==0.1.5
 cython>=0.19
 dash==0.35.2
-dash-bio==0.0.8rc11
+dash-bio==0.0.8rc12
 dash-core-components==0.36.1
 dash-daq==0.1.4
 dash-html-components==0.13.2


### PR DESCRIPTION
## About 
- [ ] This is a new component 
- [x] I am adding a feature to an existing component, or improving an existing feature
- [ ] I am closing an issue 

## Description of changes 
Remove all "unprotected" calls to  `setProps`, which is only defined as a function if there is a callback in the Dash app that uses the component as input. Also ensure that `view` has a full set of parameters at any given time (before, it would be restricted to the dictionary supplied by the user and there would be errors related to not being able to compute the rendering because of missing properties). 

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


