### PR TITLE
Sequenceviewer redesign

### DIFF
--- a/assets/sequence-viewer-style.css
+++ b/assets/sequence-viewer-style.css
@@ -1,7 +1,8 @@
 #seq-view-body {
-    font-family: 'Open Sans Light', sans-serif;
+    font-family: sans-serif;
+    font-weight: 200;
     padding: 5px;
-    background-color: #F3F6FA;
+    background-color: #FFF9FC;
     color: #303030;
     height: calc(100vh - 70px);
     overflow: auto;
@@ -11,11 +12,11 @@
     width: 4px;
     height: 0px;
     margin-right: 500px;
-    background-color: #F3F6FA;
+    background-color: #FFF9FC;
 }
 #seq-view-body ::-webkit-scrollbar-thumb {
     width: 2px;
-    background-color: #2b69fb;
+    background-color: #C50063;
     border-radius:15px;
     padding-right:5px;
 }
@@ -41,8 +42,8 @@
     overflow-y: auto;
 }
 #seq-view-control-tabs .tab--selected {
-    border-top: solid 2px #636efa;
-    color: #636efa;
+    border-top: solid 2px #C50063;
+    color: #C50063;
 }
 .seq-view-tab {
     max-height: 460px;
@@ -102,22 +103,6 @@
 #seq-view-number-entries {
     text-align: center;
 }
-#seq-view-header {
-    width: calc(100% - 40px);
-    height: auto;
-    margin: 0px;
-    font-size: 60px;
-    margin-bottom: 20px;
-    background: #C8D4E3;
-    color: #636efa;
-    font-family: 'Open Sans';
-    font-variant: all-small-caps;
-}
-
-#seq-view-header img {
-    height: 50px;
-    margin-right: 50px;
-}
 
 #sel-color, #translation-alphabet {
     width: 80%;
@@ -138,11 +123,11 @@
     font-size: 16px;
 }
 .seq-view-info-element-title {
-    font-weight: bold;
-    font-size: 16px;
+    font-size: 18px;
     margin-left: -5px;
     margin-bottom: 5px;
     display: inline-block;
+    font-weight: 300;
 }
 #preloaded-sequences, #fasta-entry-dropdown {
     width: 120px;
@@ -181,7 +166,12 @@
     margin: 10px;
     margin-left: 10%;
 }
-
+#seq-view-body .rc-slider-track {
+    background-color: #C50063;
+}
+#seq-view-body .rc-slider-handle {
+    border: solid 2px #C50063;
+}
 #sel-region-low, #sel-region-high {
     width: 40%;
     padding: 2px;
@@ -207,42 +197,43 @@
     word-wrap: break-word;
     padding-right: 10px;
     margin: 20px;
+    font-size: 10pt;
 }
 
 #seq-view-info-desc {
-    border-left: solid 5px rgba(255,0,0,0.3);
-    border-radius: 5px;
-    padding-left: 10px;
+    border-left: solid 2px #A12F80;
+    padding-left: 15px;
+    padding-bottom: 10px;
+    margin-top: 10px;
 }
 
 #seq-view-info-aa-comp {
-    border-left: solid 5px rgba(0,0,255,0.3);
-    border-radius: 5px;
-    padding-left: 10px;
+    border-left: solid 2px #74438C;
+    padding-left: 15px;
+    padding-bottom: 10px;
 }
 
 #seq-view-info-coverage-clicked {
-    border-left: solid 5px rgba(0,20,0,0.3);
-    border-radius: 5px;
-    padding-left: 10px;
+    border-left: solid 2px #494C85;
+    padding-left: 15px;
+    padding-bottom: 10px;
 }
 
 #seq-view-info-mouse-selection {
-    border-left: solid 5px rgba(255,150,0,0.3);
-    border-radius: 5px;
-    padding-left: 10px;
+    border-left: solid 2px #2E4D71;
+    padding-left: 15px;
+    padding-bottom: 10px;
 }
 
 #seq-view-info-subpart-sel {
-    border-left: solid 5px rgba(150,0,200,0.3);;
-    border-radius: 5px;
-    padding-left: 10px;
-
+    border-left: solid 2px #2F4858;
+    padding-left: 15px;
+    padding-bottom: 10px;
 }
 
 #preloaded-and-uploaded-alert {
     width:80%;
-    border: solid 1px #636efa;
+    border: solid 1px #C50063;
     border-radius: 5px;
     margin-left: calc(10% - 20px);
     margin-bottom: 30px;
@@ -252,7 +243,7 @@
 #cov-options {
     width: 80%;
     padding: 10px;
-    border: solid 1px #636efa;
+    border: solid 1px #C50063;
     border-radius: 5px;
     margin: calc(10% - 10px);
     text-align:center;
@@ -272,6 +263,6 @@
 }
 
 #seq-view-download-sample-data:hover {
-    border: solid 1px #636efa;
-    color: #6e6efa;
+    border: solid 1px #C50063;
+    color: #C50063;
 }

--- a/assets/sequence-viewer-style.css
+++ b/assets/sequence-viewer-style.css
@@ -36,6 +36,7 @@
 
 #seq-view-control-tabs .tab-content {
     padding: 20px;
+
     height: 400px;
     margin: 20px;
     overflow-y: auto;
@@ -81,6 +82,9 @@
     display: inline-block;
     margin-bottom: 5px;
     text-align: center;
+}
+#seq-view-body h4 {
+    font-size: 20pt;
 }
 #sequence-viewer .sequenceHeader.row h4 {
     height: 44px;
@@ -175,6 +179,7 @@ input#coverage-color, input#coverage-bg-color, input#coverage-tooltip {
     font-size: 10pt;
 }
 #sel-region-inputs {
+    margin-top: 30px;
     padding-left: 10px;
 }
 #seq-view-body button {

--- a/assets/sequence-viewer-style.css
+++ b/assets/sequence-viewer-style.css
@@ -53,13 +53,16 @@
     display: inline-block;
 }
 #seq-view-component-container {
-    border-radius: 5px;
     padding: 20px;
     margin:20px;
+    height: 225px;
     background-color: #fff;
 }
 #seq-view-component-container .sequenceBody.scroller {
     overflow-x: hidden;
+}
+#sequence-viewer {
+    margin-top: -10px;
 }
 #sequence-viewer input {
     width: 100% !important;
@@ -71,6 +74,9 @@
     display: inline-block;
     margin-bottom: 5px;
     text-align: center;
+}
+#sequence-viewer .sequenceHeader.row h4 {
+    height: 44px;
 }
 #seq-view-controls-container input[type=text]{
     width: 350px;
@@ -187,15 +193,14 @@
 #seq-view-info {
     overflow-y: auto;
     margin: 20px;
-    padding: 10px;
+    padding: 5px;
     padding-right: 10px;
-    height: 210px;
+    height: 215px;
 }
 
 #seq-view-info-container {
     overflow-y: auto;
-    border-radius: 5px;
-
+    background-color: #fff;
     word-wrap: break-word;
     padding-right: 10px;
     margin: 20px;

--- a/assets/sequence-viewer-style.css
+++ b/assets/sequence-viewer-style.css
@@ -101,12 +101,8 @@
 }
 
 #seq-view-number-entries {
-    text-align: center;
-}
-
-#sel-color, #translation-alphabet {
-    width: 80%;
-    margin-left: 10%;
+    margin-top: -5px;
+    font-size: 10pt;
 }
 
 .inputSearchSeq {
@@ -117,21 +113,65 @@
     border: solid 1px grey;
     margin-left: 10px;
 }
-.seq-view-controls-name{
-    font-weight: bold;
-    text-align: center;
-    font-size: 16px;
+.seq-view-controls-name {
+    display: inline-block;
+    margin-top: 5px;
+    font-weight: 400;
+    vertical-align: middle;
+    width: 160px;
+    font-size: 12pt;
 }
+#preloaded-sequences, #fasta-entry-dropdown, #selection-or-coverage, #sel-slider-or-input, #translation-alphabet, #sel-color {
+    display: inline-block;
+    padding-top: 10px;
+    float: right;
+}
+#seq-view-body input[type=radio] {
+    margin-right: 5px;
+}
+.Select, #selection-or-coverage, #sel-slider-or-input {
+    width: 140px !important;
+}
+#selection-or-coverage, #sel-slider-or-input {
+    margin-top: -5px;
+}
+#sel-slider-or-input {
+    margin-left: 15px;
+}
+#sel-region-low, #sel-region-high {
+    width: 100px;
+    padding: 5px;
+    margin-right: 10px;
+    margin-left: 10px;
+    font-size: 10pt;
+}
+#sel-region-inputs {
+    padding-left: 10px;
+}
+button#submit-sel-region  {
+    float: right;
+}
+#seq-view-body .rc-slider {
+    margin-top: 30px;
+    display: block;
+    width: calc(100% - 20px);
+    margin-left: 10px;
+}
+#seq-view-body label {
+    margin-left: 35px;
+    display: block;
+}
+
+#fasta-entry-dropdown .Select, #translation-alphabet .Select, #sel-color .Select {
+    width: 110px !important;
+}
+
 .seq-view-info-element-title {
     font-size: 18px;
     margin-left: -5px;
     margin-bottom: 5px;
     display: inline-block;
     font-weight: 300;
-}
-#preloaded-sequences, #fasta-entry-dropdown {
-    width: 120px;
-    padding-left: 25px;
 }
 
 #seq-view-upload-display {
@@ -140,16 +180,15 @@
     width: auto;
 
 }
-#seq-view-fasta-upload{
-    height: 50px;
-    line-height: 60px;
-    border-width: 1px;
-    border-style: dashed;
+#seq-view-fasta-upload {
+    border: dashed 1px #C50063;
     border-radius: 5px;
     text-align: center;
-    margin: 20px;
-    top: 10px;
-    padding: 10px;
+    margin-top: 50px;
+    margin-bottom: 10px;
+    padding: 20px;
+    font-size: 9pt;
+    width: calc(100% - 42px);
 }
 
 
@@ -160,27 +199,11 @@
     word-wrap: break-word;
 }
 
-
-#seq-view-body .rc-slider {
-    width: 80%;
-    margin: 10px;
-    margin-left: 10%;
-}
 #seq-view-body .rc-slider-track {
     background-color: #C50063;
 }
 #seq-view-body .rc-slider-handle {
     border: solid 2px #C50063;
-}
-#sel-region-low, #sel-region-high {
-    width: 40%;
-    padding: 2px;
-    margin: 2px;
-    font-size: 10pt;
-}
-
-#sel-slider-or-input label {
-    display: inline;
 }
 
 #seq-view-info {
@@ -248,13 +271,11 @@
     margin: calc(10% - 10px);
     text-align:center;
 }
-#selection-or-coverage {
-    margin-left: 10px;
-}
 
 #seq-view-download-sample-data {
     height: 42px;
-    margin-left: 20px;
+    font-size: 8pt;
+    width: 100%;
     padding-left: 10px;
     padding-right: 10px;
     transition-duration: 500ms;

--- a/assets/sequence-viewer-style.css
+++ b/assets/sequence-viewer-style.css
@@ -7,7 +7,6 @@
     height: calc(100vh - 70px);
     overflow: auto;
 }
-
 #seq-view-body ::-webkit-scrollbar {
     width: 4px;
     height: 0px;
@@ -68,6 +67,10 @@
 #sequence-viewer {
     margin-top: -10px;
 }
+#seq-view-body hr {
+    margin-top: 30px;
+    margin-bottom: 10px;
+}
 #sequence-viewer input {
     width: 100% !important;
     margin-left: 0px;
@@ -90,6 +93,7 @@
 #coverage-submit, #coverage-reset {
     width: 45%;
     padding: 0px;
+    margin-top: 20px;
     font-size: 7pt;
     margin-top:5px;
 }
@@ -121,22 +125,47 @@
     width: 160px;
     font-size: 12pt;
 }
-#preloaded-sequences, #fasta-entry-dropdown, #selection-or-coverage, #sel-slider-or-input, #translation-alphabet, #sel-color {
+#preloaded-sequences, #fasta-entry-dropdown, #selection-or-coverage, #sel-slider-or-input, #translation-alphabet, #sel-color, #mouse-sel-or-subpart-sel, #coverage-color, #coverage-bg-color, #coverage-tooltip, #coverage-underscore {
     display: inline-block;
     padding-top: 10px;
     float: right;
 }
+#preloaded-sequences {
+    padding-top: 0px;
+}
+#coverage-underscore {
+    float: none;
+    margin-left: 12px;
+    position: relative;
+    top: 5px;
+}
+#mouse-sel-or-subpart-sel label {
+    margin-left: 40px !important;
+}
+input#coverage-color, input#coverage-bg-color, input#coverage-tooltip {
+    padding: 2px 6px;
+    height: 30px;
+    margin-top: 5px;
+    margin-left: 50px;
+}
+
 #seq-view-body input[type=radio] {
     margin-right: 5px;
 }
-.Select, #selection-or-coverage, #sel-slider-or-input {
+.Select, #selection-or-coverage, #sel-slider-or-input, #mouse-sel-or-subpart-sel {
     width: 140px !important;
 }
 #selection-or-coverage, #sel-slider-or-input {
     margin-top: -5px;
 }
+#cov-options .seq-view-controls-name {
+    margin-top: 10px;
+}
 #sel-slider-or-input {
     margin-left: 15px;
+}
+#coverage-color, #coverage-bg-color, #coverage-tooltip {
+    width: 100px !important;
 }
 #sel-region-low, #sel-region-high {
     width: 100px;
@@ -148,8 +177,19 @@
 #sel-region-inputs {
     padding-left: 10px;
 }
-button#submit-sel-region  {
-    float: right;
+#seq-view-body button {
+    transition-duration: 500ms;
+    border: solid 1px #303030;
+    color: #303030;
+
+}
+#coverage-submit {
+    margin-top: 15px;
+    margin-right: 15px;
+}
+#coverage-reset {
+    margin-top: 15px;
+    margin-left: 15px;
 }
 #seq-view-body .rc-slider {
     margin-top: 30px;
@@ -161,9 +201,16 @@ button#submit-sel-region  {
     margin-left: 35px;
     display: block;
 }
+#selection-or-coverage label{
+    margin-left: 30px;
+}
 
 #fasta-entry-dropdown .Select, #translation-alphabet .Select, #sel-color .Select {
     width: 110px !important;
+}
+#fasta-entry-dropdown, #selection-or-coverage {
+    position: relative;
+    top: -5px;
 }
 
 .seq-view-info-element-title {
@@ -263,27 +310,15 @@ button#submit-sel-region  {
     padding: 20px;
 }
 
-#cov-options {
-    width: 80%;
-    padding: 10px;
-    border: solid 1px #C50063;
-    border-radius: 5px;
-    margin: calc(10% - 10px);
-    text-align:center;
-}
-
 #seq-view-download-sample-data {
     height: 42px;
     font-size: 8pt;
     width: 100%;
     padding-left: 10px;
     padding-right: 10px;
-    transition-duration: 500ms;
-    border: solid 1px black;
-    color: #303030;
 }
 
-#seq-view-download-sample-data:hover {
+#seq-view-body button:hover {
     border: solid 1px #C50063;
     color: #C50063;
 }

--- a/assets/sequence-viewer-style.css
+++ b/assets/sequence-viewer-style.css
@@ -1,25 +1,79 @@
-@import url('https://fonts.googleapis.com/css?family=Open+Sans');
-
 #seq-view-body {
-    position: absolute;
+    font-family: 'Open Sans Light', sans-serif;
+    padding: 5px;
+    background-color: #F3F6FA;
+    color: #303030;
+    height: calc(100vh - 70px);
     overflow: auto;
-    top: 0px;
-    left: 0px;
-    bottom: 0px; 
-    width: 100%;
-    min-height: calc(100vh - 100px);
-    padding-top: 0px; 
-    background-color: #F3F6FA; 
-    font-family: 'Open Sans'; 
 }
 
-#sequence-viewer input {
-    width: 80% !important;
-    
-} 
+#seq-view-body ::-webkit-scrollbar {
+    width: 4px;
+    height: 0px;
+    margin-right: 500px;
+    background-color: #F3F6FA;
+}
+#seq-view-body ::-webkit-scrollbar-thumb {
+    width: 2px;
+    background-color: #2b69fb;
+    border-radius:15px;
+    padding-right:5px;
+}
 
+#seq-view-wrapper::-webkit-scrollbar {
+    display: none;
+}
+
+#seq-view-control-tabs {
+    width: 400px;
+    height: 550px;
+    margin: 50px;
+    margin-right: 0px;
+    background-color: #fff;
+    font-size: 10pt;
+    float: left;
+}
+
+#seq-view-control-tabs .tab-content {
+    padding: 20px;
+    height: 400px;
+    margin: 20px;
+    overflow-y: auto;
+}
+
+.seq-view-tab {
+    max-height: 460px;
+    overflow-y: auto;
+    padding-right: 15px;
+}
+#seq-view-container {
+    width: 500px;
+    margin-top: 30px;
+    margin-left: 30px;
+    display: inline-block;
+}
+#seq-view-component-container {
+    border-radius: 5px;
+    padding: 20px;
+    margin:20px;
+    background-color: #fff;
+}
+#seq-view-component-container .sequenceBody.scroller {
+    overflow-x: hidden;
+}
+#sequence-viewer input {
+    width: 100% !important;
+    margin-left: 0px;
+    margin-bottom: 5px;
+    font-size: 10pt;
+}
+#sequence-viewer span.badge {
+    display: inline-block;
+    margin-bottom: 5px;
+    text-align: center;
+}
 #seq-view-controls-container input[type=text]{
-    width: 80%;
+    width: 350px;
     margin-left:auto;
 }
 
@@ -27,7 +81,7 @@
     width: 45%;
     padding: 0px;
     font-size: 7pt;
-    margin-top:5px; 
+    margin-top:5px;
 }
 #coverage-submit {
     margin-right: 5%;
@@ -35,19 +89,6 @@
 #coverage-reset {
     margin-left: 5%;
 }
-
-#seq-view-body ::-webkit-scrollbar {
-    width: 4px;
-    height: 0px;
-    margin-right: 500px; 
-    background-color: white;
-}
-#seq-view-body ::-webkit-scrollbar-thumb {
-    width: 2px;
-    background-color: rgb(43, 105, 251);
-    border-radius:15px;
-    padding-right:5px; 
-} 
 
 #seq-view-number-entries {
     text-align: center;
@@ -57,7 +98,7 @@
     height: auto;
     margin: 0px;
     font-size: 60px;
-    margin-bottom: 20px; 
+    margin-bottom: 20px;
     background: #C8D4E3;
     color: #636efa;
     font-family: 'Open Sans';
@@ -66,12 +107,12 @@
 
 #seq-view-header img {
     height: 50px;
-    margin-right: 50px; 
+    margin-right: 50px;
 }
 
 #sel-color, #translation-alphabet {
     width: 80%;
-    margin-left: 10%; 
+    margin-left: 10%;
 }
 
 .inputSearchSeq {
@@ -85,54 +126,38 @@
 .seq-view-controls-name{
     font-weight: bold;
     text-align: center;
-    font-size: 16px; 
+    font-size: 16px;
 }
 .seq-view-info-element-title {
     font-weight: bold;
     font-size: 16px;
     margin-left: -5px;
+    margin-bottom: 5px;
+    display: inline-block;
 }
 #preloaded-sequences, #fasta-entry-dropdown {
     width: 120px;
-    padding-left: 25px; 
+    padding-left: 25px;
 }
 
 #seq-view-upload-display {
     display: inline-block;
-    vertical-align: top; 
+    vertical-align: top;
     width: auto;
-    
+
 }
 #seq-view-fasta-upload{
-    width: 450px;
     height: 50px;
     line-height: 60px;
     border-width: 1px;
     border-style: dashed;
     border-radius: 5px;
-    text-align: center; 
+    text-align: center;
     margin: 20px;
-    top: 10px; 
+    top: 10px;
     padding: 10px;
-}
-#sequence-viewer-container{
-    width: 450px;
-    border: solid 1px #636efa;
-    border-radius: 5px;
-    padding: 10px;
-    margin:20px;
 }
 
-#seq-view-controls-container {
-    width:175px;
-    display: inline-block;
-    vertical-align: top;
-    margin: 20px; 
-    padding: 10px;
-    padding-top:30px;
-    border: solid 1px #636efa; 
-    border-radius: 5px;
-}
 
 #seq-view-controls {
     overflow-y: auto;
@@ -141,14 +166,7 @@
     word-wrap: break-word;
 }
 
-#seq-view-sel-slider-container {
-    width: 80%;
-    padding: 10px;
-    border: solid 1px #636efa; 
-    border-radius: 5px;
-    margin: calc(10% - 10px); 
-    text-align:center;
-}
+
 #seq-view-body .rc-slider {
     width: 80%;
     margin: 10px;
@@ -158,62 +176,59 @@
 #sel-region-low, #sel-region-high {
     width: 40%;
     padding: 2px;
-    margin: 2px; 
-    font-size: 10pt; 
+    margin: 2px;
+    font-size: 10pt;
 }
 
 #sel-slider-or-input label {
-    display: inline; 
-} 
-
-#seq-view-info-container {
-    width: calc(100vw - 850px);
-    min-width: 440px; 
-    border: solid 1px #636efa; 
-    overflow-y: auto;
-    margin: 20px;
-    vertical-align: top; 
-    border-radius: 5px;
-    padding: 20px;
-    padding-right: 10px; 
-    display: inline-block;
+    display: inline;
 }
 
 #seq-view-info {
-    height: 600px;
     overflow-y: auto;
+    margin: 20px;
+    padding: 10px;
+    padding-right: 10px;
+    height: 210px;
+}
+
+#seq-view-info-container {
+    overflow-y: auto;
+    border-radius: 5px;
+
     word-wrap: break-word;
-    padding-right: 10px; 
+    padding-right: 10px;
+    margin: 20px;
 }
 
 #seq-view-info-desc {
     border-left: solid 5px rgba(255,0,0,0.3);
     border-radius: 5px;
-    padding-left: 10px; 
+    padding-left: 10px;
 }
 
 #seq-view-info-aa-comp {
-    border-left: solid 5px rgba(0,0,255,0.3); 
+    border-left: solid 5px rgba(0,0,255,0.3);
     border-radius: 5px;
-    padding-left: 10px; 
+    padding-left: 10px;
 }
 
 #seq-view-info-coverage-clicked {
     border-left: solid 5px rgba(0,20,0,0.3);
     border-radius: 5px;
-    padding-left: 10px; 
+    padding-left: 10px;
 }
 
 #seq-view-info-mouse-selection {
     border-left: solid 5px rgba(255,150,0,0.3);
     border-radius: 5px;
-    padding-left: 10px; 
+    padding-left: 10px;
 }
 
 #seq-view-info-subpart-sel {
     border-left: solid 5px rgba(150,0,200,0.3);;
     border-radius: 5px;
-    padding-left: 10px; 
+    padding-left: 10px;
 
 }
 
@@ -222,16 +237,16 @@
     border: solid 1px #636efa;
     border-radius: 5px;
     margin-left: calc(10% - 20px);
-    margin-bottom: 30px; 
-    padding: 20px; 
+    margin-bottom: 30px;
+    padding: 20px;
 }
 
 #cov-options {
     width: 80%;
     padding: 10px;
-    border: solid 1px #636efa; 
+    border: solid 1px #636efa;
     border-radius: 5px;
-    margin: calc(10% - 10px); 
+    margin: calc(10% - 10px);
     text-align:center;
 }
 #selection-or-coverage {
@@ -239,15 +254,14 @@
 }
 
 #seq-view-download-sample-data {
-    width: 470px;
     height: 42px;
     margin-left: 20px;
     padding-left: 10px;
-    padding-right: 10px; 
+    padding-right: 10px;
     transition-duration: 500ms;
     border: solid 1px black;
     color: #303030;
-} 
+}
 
 #seq-view-download-sample-data:hover {
     border: solid 1px #636efa;

--- a/assets/sequence-viewer-style.css
+++ b/assets/sequence-viewer-style.css
@@ -40,7 +40,10 @@
     margin: 20px;
     overflow-y: auto;
 }
-
+#seq-view-control-tabs .tab--selected {
+    border-top: solid 2px #636efa;
+    color: #636efa;
+}
 .seq-view-tab {
     max-height: 460px;
     overflow-y: auto;

--- a/tests/dashbio_demos/app_sequence_viewer.py
+++ b/tests/dashbio_demos/app_sequence_viewer.py
@@ -357,90 +357,91 @@ def layout():
                         ]),
 
                         html.Div(id='seq-view-sel-slider-container', children=[
-                                html.Div(className='seq-view-controls-name',
-                                         children="Selection region:"),
-                                dcc.RadioItems(
-                                    id='sel-slider-or-input',
-                                    options=[
-                                        {'label': 'slider', 'value': 'slider'},
-                                        {'label': 'input', 'value': 'input'}
-                                    ],
-                                    value='slider'
-                                ),
-                                dcc.RangeSlider(
-                                    id='sel-slider',
-                                    min=0,
-                                    max=0,
-                                    step=1,
-                                    value=[0, 0]
-                                ),
-                                # optional numeric input for longer sequences
-                                html.Div(
-                                    id='sel-region-inputs',
-                                    children=[
-                                        "From: ",
-                                        dcc.Input(
-                                            id='sel-region-low',
-                                            type='number',
-                                            min=0,
-                                            max=0,
-                                            placeholder="low"
-                                        ),
-                                        "To: ",
-                                        dcc.Input(
-                                            id='sel-region-high',
-                                            type='number',
-                                            min=0,
-                                            max=0,
-                                            placeholder="high"
-                                        ),
-                                    ],
-                                    style={'display': 'none'}
-                                ),
+                            html.Div(
+                                className='seq-view-controls-name',
+                                children="Selection region:"
+                            ),
+                            dcc.RadioItems(
+                                id='sel-slider-or-input',
+                                options=[
+                                    {'label': 'slider', 'value': 'slider'},
+                                    {'label': 'input', 'value': 'input'}
+                                ],
+                                value='slider'
+                            ),
+                            dcc.RangeSlider(
+                                id='sel-slider',
+                                min=0,
+                                max=0,
+                                step=1,
+                                value=[0, 0]
+                            ),
+                            # optional numeric input for longer sequences
+                            html.Div(
+                                id='sel-region-inputs',
+                                children=[
+                                    "From: ",
+                                    dcc.Input(
+                                        id='sel-region-low',
+                                        type='number',
+                                        min=0,
+                                        max=0,
+                                        placeholder="low"
+                                    ),
+                                    "To: ",
+                                    dcc.Input(
+                                        id='sel-region-high',
+                                        type='number',
+                                        min=0,
+                                        max=0,
+                                        placeholder="high"
+                                    ),
+                                ],
+                                style={'display': 'none'}
+                            ),
 
-                                html.Br(),
+                            html.Br(),
 
-                                html.Div(
-                                    id='seq-view-dna-or-protein-container',
-                                    children=[
-                                        html.Div(
-                                            className='seq-view-controls-name',
-                                            children="Translate selection from:"
-                                        ),
-                                        dcc.Dropdown(
-                                            id='translation-alphabet',
-                                            options=[
-                                                {'label': 'DNA',
-                                                 'value': 'dna'},
-                                                {'label': 'RNA',
-                                                 'value': 'rna'}
-                                            ],
-                                            value=None
-                                        )
-                                    ]
-                                ),
+                            html.Div(
+                                id='seq-view-dna-or-protein-container',
+                                children=[
+                                    html.Div(
+                                        className='seq-view-controls-name',
+                                        children="Translate selection from:"
+                                    ),
+                                    dcc.Dropdown(
+                                        id='translation-alphabet',
+                                        options=[
+                                            {'label': 'DNA',
+                                             'value': 'dna'},
+                                            {'label': 'RNA',
+                                             'value': 'rna'}
+                                        ],
+                                        value=None
+                                    )
+                                ]
+                            ),
 
-                                html.Br(),
+                            html.Br(),
 
-                                html.Div(
-                                    className='seq-view-controls-name',
-                                    children="Selection highlight color:"
-                                ),
-                                dcc.Dropdown(
-                                    id='sel-color',
-                                    options=[
-                                        {'label': 'violet', 'value': 'violet'},
-                                        {'label': 'indigo', 'value': 'indigo'},
-                                        {'label': 'blue', 'value': 'blue'},
-                                        {'label': 'green', 'value': 'green'},
-                                        {'label': 'yellow', 'value': 'yellow'},
-                                        {'label': 'orange', 'value': 'orange'},
-                                        {'label': 'red', 'value': 'red'}
-                                    ],
-                                    value='indigo'
-                                )
-                            ]
-                        )
+                            html.Div(
+                                className='seq-view-controls-name',
+                                children="Selection highlight color:"
+                            ),
+                            dcc.Dropdown(
+                                id='sel-color',
+                                options=[
+                                    {'label': 'violet', 'value': 'violet'},
+                                    {'label': 'indigo', 'value': 'indigo'},
+                                    {'label': 'blue', 'value': 'blue'},
+                                    {'label': 'green', 'value': 'green'},
+                                    {'label': 'yellow', 'value': 'yellow'},
+                                    {'label': 'orange', 'value': 'orange'},
+                                    {'label': 'red', 'value': 'red'}
+                                ],
+                                value='indigo'
+                            )
+                        ])
                     ]
                 ),
 

--- a/tests/dashbio_demos/app_sequence_viewer.py
+++ b/tests/dashbio_demos/app_sequence_viewer.py
@@ -69,356 +69,368 @@ def layout():
 
     return html.Div(id='seq-view-body', children=[
         html.Div(
-            id='seq-view-upload-display',
+            id='seq-view-container',
             children=[
                 html.Div(
-                    id='seq-view-fasta-upload',
-                    children=[
-                        dcc.Upload(
-                            id='upload-fasta-data',
-                            children=html.Div([
-                                "Drag and drop or click to upload a \
-                                file."
-                            ]),
-                        ),
-                    ]
-                ),
-
-                html.Div(
-                    children=[
-                        html.A(
-                            html.Button(
-                                "Download sample FASTA data",
-                                id='seq-view-download-sample-data'
-                            ),
-                            href="/assets/sample_data/tubulin.fasta.txt",
-                            download="tubulin.fasta.txt"
-                        )
-                    ]
-                ),
-
-                html.Div(
-                    id='sequence-viewer-container',
+                    id='seq-view-component-container',
                     children=[
                         dash_bio.SequenceViewer(
                             id='sequence-viewer',
+                            sequenceMaxHeight='100px'
+                        ),
+                    ]
+                ),
+                html.Div(id='seq-view-info-container', children=html.Div(
+                    id='seq-view-info',
+                    children=[
+                        html.Div(id='seq-view-info-desc',
+                                 children=[
+                                     html.Span(
+                                         "Description: ",
+                                         className='seq-view-info-element-title'
+                                     ),
+                                     html.Div(
+                                         id='desc-info',
+                                         children=[]
+                                     )
+                                 ]),
+
+                        html.Br(),
+
+                        html.Div(id='seq-view-info-aa-comp',
+                                 children=[
+                                     html.Span(
+                                         "Amino acid composition: ",
+                                         className='seq-view-info-element-title'
+                                     ),
+                                     html.Div(
+                                         id='test-selection'
+                                     )
+                                 ]),
+
+                        html.Br(),
+
+                        html.Div(id='seq-view-info-coverage-clicked',
+                                 children=[
+                                     html.Span(
+                                         "Coverage entry clicked: ",
+                                         className='seq-view-info-element-title'
+                                     ),
+                                     html.Div(
+                                         id='test-coverage-clicked'
+                                     )
+                                 ]),
+
+                        html.Br(),
+
+                        html.Div(id='seq-view-info-mouse-selection',
+                                 children=[
+                                     html.Span(
+                                         "Mouse selection: ",
+                                         className='seq-view-info-element-title'
+                                     ),
+                                     html.Div(
+                                         id='test-mouse-selection'
+                                     )
+                                 ]),
+
+                        html.Br(),
+
+                        html.Div(id='seq-view-info-subpart-sel', children=[
+                            html.Span(
+                                "Subpart selected: ",
+                                className='seq-view-info-element-title'
+                            ),
+                            html.Div(
+                                id='test-subpart-selection'
+                            )
+                        ])
+                    ]
+                ))
+            ]
+        ),
+
+        html.Div(id='seq-view-control-tabs', children=[
+            dcc.Tabs(id='seq-view-tabs', children=[
+                dcc.Tab(
+                    label='About',
+                    value='what-is',
+                    children=html.Div(className='seq-view-tab', children=[
+                        html.H4('What is Sequence Viewer?'),
+                        html.P(description())
+                    ])
+                ),
+                dcc.Tab(
+                    label='Data',
+                    value='data',
+                    children=[
+                        html.Div(
+                            id='preloaded-and-uploaded-alert',
+                            children=[
+                                'You have uploaded your own data. In order \
+                                to view it, please ensure that the "preloaded \
+                                sequences" dropdown has been cleared.'
+                            ],
+                            style={'display': 'none'}
+                        ),
+
+                        html.Div(
+                            "Preloaded sequences",
+                            className='seq-view-controls-name'
+                        ),
+                        dcc.Dropdown(
+                            id='preloaded-sequences',
+                            options=[
+                                {
+                                    'label': 'insulin',
+                                    'value': '{}P01308.fasta.txt'.format(DATAPATH)
+                                },
+                                {
+                                    'label': 'keratin',
+                                    'value': '{}P04264.fasta.txt'.format(DATAPATH)
+                                },
+                                {
+                                    'label': 'albumin',
+                                    'value': '{}NX_P02768.fasta.txt'.format(DATAPATH)
+                                },
+                                {
+                                    'label': 'myosin (gene)',
+                                    'value': '{}myosin.fasta.txt'.format(DATAPATH)
+                                },
+                                {
+                                    'label': 'HflX (gene)',
+                                    'value': '{}hflx.fasta.txt'.format(DATAPATH)
+                                }
+                            ],
+                            value='{}P01308.fasta.txt'.format(DATAPATH)
+                        ),
+
+                        html.Div(
+                            id='seq-view-fasta-upload',
+                            children=[
+                                dcc.Upload(
+                                    id='upload-fasta-data',
+                                    children=html.Div([
+                                        "Drag and drop or click to upload a \
+                                        file."
+                                    ]),
+                                ),
+                            ]
+                        ),
+
+                        html.Div(
+                            children=[
+                                html.A(
+                                    html.Button(
+                                        "Download sample FASTA data",
+                                        id='seq-view-download-sample-data'
+                                    ),
+                                    href="/assets/sample_data/tubulin.fasta.txt",
+                                    download="tubulin.fasta.txt"
+                                )
+                            ]
                         )
                     ]
-                )
-            ]
-        ),
+                ),
+                dcc.Tab(
+                    label='Sequence',
+                    value='sequence',
+                    children=[
+                        html.Div(
+                            id='seq-view-entry-dropdown-container',
+                            children=[
+                                html.Div(
+                                    "View entry:",
+                                    className='seq-view-controls-name'
+                                ),
+                                html.Div(
+                                    id='seq-view-number-entries'
+                                ),
+                                dcc.Dropdown(
+                                    id='fasta-entry-dropdown',
+                                    options=[
+                                        {'label': 1, 'value': 0}
+                                    ],
+                                    value=0
+                                )
+                            ]
+                        ),
+                        html.Br(),
+                        html.Div(
+                            id='seq-view-sel-or-cov-container',
+                            children=[
+                                html.Div(
+                                    "Selection or coverage",
+                                    className='seq-view-controls-name'
+                                ),
+                                dcc.RadioItems(
+                                    id='selection-or-coverage',
+                                    options=[
+                                        {
+                                            'label': 'Enable selection',
+                                            'value': 'sel'
+                                        },
+                                        {
+                                            'label': 'Enable coverage',
+                                            'value': 'cov'
+                                        }
+                                    ],
+                                    value='sel'
+                                )
+                            ]
+                        ),
 
-        html.Div(
-            id='seq-view-controls-container',
-            children=[
-                html.Div(id='seq-view-controls', children=[
-                    html.Div(
-                        "Preloaded sequences",
-                        className='seq-view-controls-name'
-                    ),
-                    dcc.Dropdown(
-                        id='preloaded-sequences',
-                        options=[
-                            {
-                                'label': 'insulin',
-                                'value': '{}P01308.fasta.txt'.format(DATAPATH)
-                            },
-                            {
-                                'label': 'keratin',
-                                'value': '{}P04264.fasta.txt'.format(DATAPATH)
-                            },
-                            {
-                                'label': 'albumin',
-                                'value': '{}NX_P02768.fasta.txt'.format(DATAPATH)
-                            },
-                            {
-                                'label': 'myosin (gene)',
-                                'value': '{}myosin.fasta.txt'.format(DATAPATH)
-                            },
-                            {
-                                'label': 'HflX (gene)',
-                                'value': '{}hflx.fasta.txt'.format(DATAPATH)
-                            }
-                        ],
-                        value='{}P01308.fasta.txt'.format(DATAPATH)
-                    ),
-                    html.Br(),
-                    html.Div(
-                        id='seq-view-entry-dropdown-container',
-                        children=[
+
+                        html.Hr(),
+
+                        html.Div(id='cov-options', children=[
                             html.Div(
-                                "View entry:",
-                                className='seq-view-controls-name'
-                            ),
-                            html.Div(
-                                id='seq-view-number-entries'
-                            ),
-                            dcc.Dropdown(
-                                id='fasta-entry-dropdown',
-                                options=[
-                                    {'label': 1, 'value': 0}
-                                ],
-                                value=0
-                            )
-                        ]
-                    ),
-                    html.Br(),
-                    html.Div(
-                        id='seq-view-sel-or-cov-container',
-                        children=[
-                            html.Div(
-                                "Selection or coverage",
-                                className='seq-view-controls-name'
+                                "Add coverage",
+                                style={'font-weight': 'bold'}
                             ),
                             dcc.RadioItems(
-                                id='selection-or-coverage',
+                                id='mouse-sel-or-subpart-sel',
                                 options=[
-                                    {
-                                        'label': 'Enable selection',
-                                        'value': 'sel'
-                                    },
-                                    {
-                                        'label': 'Enable coverage',
-                                        'value': 'cov'
-                                    }
+                                    {'label': 'Use mouse selection',
+                                     'value': 'mouse'},
+                                    {'label': 'Use subpart selection',
+                                     'value': 'subpart'}
                                 ],
-                                value='sel'
-                            )
-                        ]
-                    ),
+                                value='mouse'
+                            ),
+                            html.Br(),
+                            'Text color: ',
+                            dcc.Input(
+                                id='coverage-color',
+                                type='text',
+                                value='rgb(255, 0, 0)'
+                            ),
+                            'Background color: ',
+                            dcc.Input(
+                                id='coverage-bg-color',
+                                type='text',
+                                value='rgb(0, 0, 255)'
+                            ),
+                            'Tooltip: ',
+                            dcc.Input(
+                                id='coverage-tooltip',
+                                type='text',
+                                value='',
+                                placeholder='hover text'
+                            ),
+                            dcc.Checklist(
+                                id='coverage-underscore',
+                                options=[
+                                    {'label': 'underscore text',
+                                     'value': 'underscore'}
+                                ],
+                                values=[]
+                            ),
+                            html.Br(),
+                            html.Button(
+                                id='coverage-submit',
+                                children='Submit'
+                            ),
+                            html.Button(
+                                id='coverage-reset',
+                                children='Reset'
+                            ),
+                        ]),
 
-
-                    html.Hr(),
-
-                    html.Div(id='cov-options', children=[
                         html.Div(
-                            "Add coverage",
-                            style={'font-weight': 'bold'}
-                        ),
-                        dcc.RadioItems(
-                            id='mouse-sel-or-subpart-sel',
-                            options=[
-                                {'label': 'Use mouse selection',
-                                 'value': 'mouse'},
-                                {'label': 'Use subpart selection',
-                                 'value': 'subpart'}
-                            ],
-                            value='mouse'
-                        ),
-                        html.Br(),
-                        'Text color: ',
-                        dcc.Input(
-                            id='coverage-color',
-                            type='text',
-                            value='rgb(255, 0, 0)'
-                        ),
-                        'Background color: ',
-                        dcc.Input(
-                            id='coverage-bg-color',
-                            type='text',
-                            value='rgb(0, 0, 255)'
-                        ),
-                        'Tooltip: ',
-                        dcc.Input(
-                            id='coverage-tooltip',
-                            type='text',
-                            value='',
-                            placeholder='hover text'
-                        ),
-                        dcc.Checklist(
-                            id='coverage-underscore',
-                            options=[
-                                {'label': 'underscore text',
-                                 'value': 'underscore'}
-                            ],
-                            values=[]
-                        ),
-                        html.Br(),
-                        html.Button(
-                            id='coverage-submit',
-                            children='Submit'
-                        ),
-                        html.Button(
-                            id='coverage-reset',
-                            children='Reset'
-                        ),
-                        dcc.Store(
-                            id='coverage-storage',
-                            data=initialCov
-                        ),
-                        dcc.Store(
-                            id='clear-coverage',
-                            data=0
-                        ),
-                        dcc.Store(
-                            id='current-sequence',
-                            data=0
+                            id='seq-view-sel-slider-container',
+                            children=[
+                                "Selection region",
+                                dcc.RadioItems(
+                                    id='sel-slider-or-input',
+                                    options=[
+                                        {'label': 'slider', 'value': 'slider'},
+                                        {'label': 'input', 'value': 'input'}
+                                    ],
+                                    value='slider'
+                                ),
+                                dcc.RangeSlider(
+                                    id='sel-slider',
+                                    min=0,
+                                    max=0,
+                                    step=1,
+                                    value=[0, 0]
+                                ),
+                                # optional numeric input for longer sequences
+                                html.Div(
+                                    id='sel-region-inputs',
+                                    children=[
+                                        dcc.Input(
+                                            id='sel-region-low',
+                                            type='number',
+                                            min=0,
+                                            max=0,
+                                            placeholder="low"
+                                        ),
+                                        dcc.Input(
+                                            id='sel-region-high',
+                                            type='number',
+                                            min=0,
+                                            max=0,
+                                            placeholder="high"
+                                        ),
+                                        html.Button(id='submit-sel-region',
+                                                    children="Submit")
+                                    ],
+                                    style={'display': 'none'}
+                                ),
+
+                                html.Br(),
+
+                                html.Div(
+                                    id='seq-view-dna-or-protein-container',
+                                    children=[
+                                        "Translate from",
+                                        dcc.Dropdown(
+                                            id='translation-alphabet',
+                                            options=[
+                                                {'label': 'DNA',
+                                                 'value': 'dna'},
+                                                {'label': 'RNA',
+                                                 'value': 'rna'}
+                                            ],
+                                            value=None
+                                        )
+                                    ]
+                                ),
+
+                                html.Br(),
+                                "Color",
+                                dcc.Dropdown(
+                                    id='sel-color',
+                                    options=[
+                                        {'label': 'violet', 'value': 'violet'},
+                                        {'label': 'indigo', 'value': 'indigo'},
+                                        {'label': 'blue', 'value': 'blue'},
+                                        {'label': 'green', 'value': 'green'},
+                                        {'label': 'yellow', 'value': 'yellow'},
+                                        {'label': 'orange', 'value': 'orange'},
+                                        {'label': 'red', 'value': 'red'}
+                                    ],
+                                    value='blue'
+                                ),
+                            ]
                         )
                     ]),
-
-                    html.Div(
-                        id='seq-view-sel-slider-container',
-                        children=[
-                            "Selection region",
-                            dcc.RadioItems(
-                                id='sel-slider-or-input',
-                                options=[
-                                    {'label': 'slider', 'value': 'slider'},
-                                    {'label': 'input', 'value': 'input'}
-                                ],
-                                value='slider'
-                            ),
-                            dcc.RangeSlider(
-                                id='sel-slider',
-                                min=0,
-                                max=0,
-                                step=1,
-                                value=[0, 0]
-                            ),
-                            # optional numeric input for longer sequences
-                            html.Div(
-                                id='sel-region-inputs',
-                                children=[
-                                    dcc.Input(
-                                        id='sel-region-low',
-                                        type='number',
-                                        min=0,
-                                        max=0,
-                                        placeholder="low"
-                                    ),
-                                    dcc.Input(
-                                        id='sel-region-high',
-                                        type='number',
-                                        min=0,
-                                        max=0,
-                                        placeholder="high"
-                                    ),
-                                    html.Button(id='submit-sel-region',
-                                                children="Submit")
-                                ],
-                                style={'display': 'none'}
-                            ),
-
-                            html.Br(),
-
-                            html.Div(
-                                id='seq-view-dna-or-protein-container',
-                                children=[
-                                    "Translate from",
-                                    dcc.Dropdown(
-                                        id='translation-alphabet',
-                                        options=[
-                                            {'label': 'DNA',
-                                             'value': 'dna'},
-                                            {'label': 'RNA',
-                                             'value': 'rna'}
-                                        ],
-                                        value=None
-                                    )
-                                ]
-                            ),
-
-                            html.Br(),
-                            "Color",
-                            dcc.Dropdown(
-                                id='sel-color',
-                                options=[
-                                    {'label': 'violet', 'value': 'violet'},
-                                    {'label': 'indigo', 'value': 'indigo'},
-                                    {'label': 'blue', 'value': 'blue'},
-                                    {'label': 'green', 'value': 'green'},
-                                    {'label': 'yellow', 'value': 'yellow'},
-                                    {'label': 'orange', 'value': 'orange'},
-                                    {'label': 'red', 'value': 'red'}
-                                ],
-                                value='blue'
-                            ),
-                        ]
-                    ),
-
-                ])
-            ]
-        ),
-
-        html.Div(
-            id='seq-view-info-container',
-            children=[
-                html.Div(id='seq-view-info', children=[
-                    html.Div(
-                        id='preloaded-and-uploaded-alert',
-                        children=[
-                            'You have uploaded your own data. In order \
-                            to view it, please ensure that the "preloaded \
-                            sequences" dropdown has been cleared.'
-                        ],
-                        style={'display': 'none'}
-                    ),
-
-                    html.Div(id='seq-view-info-desc',
-                             children=[
-                                 html.Span(
-                                     "Description: ",
-                                     className='seq-view-info-element-title'
-                                 ),
-                                 html.Div(
-                                     id='desc-info',
-                                     children=[]
-                                 )
-                             ]),
-
-                    html.Br(),
-
-                    html.Div(id='seq-view-info-aa-comp',
-                             children=[
-                                 html.Span(
-                                     "Amino acid composition: ",
-                                     className='seq-view-info-element-title'
-                                 ),
-                                 html.Div(
-                                     id='test-selection'
-                                 )
-                             ]),
-
-                    html.Br(),
-
-                    html.Div(id='seq-view-info-coverage-clicked',
-                             children=[
-                                 html.Span(
-                                     "Coverage entry clicked: ",
-                                     className='seq-view-info-element-title'
-                                 ),
-                                 html.Div(
-                                     id='test-coverage-clicked'
-                                 )
-                             ]),
-
-                    html.Br(),
-
-                    html.Div(id='seq-view-info-mouse-selection',
-                             children=[
-                                 html.Span(
-                                     "Mouse selection: ",
-                                     className='seq-view-info-element-title'
-                                 ),
-                                 html.Div(
-                                     id='test-mouse-selection'
-                                 )
-                             ]),
-
-                    html.Br(),
-
-                    html.Div(id='seq-view-info-subpart-sel',
-                             children=[
-                                 html.Span(
-                                     "Subpart selected: ",
-                                     className='seq-view-info-element-title'
-                                 ),
-                                 html.Div(
-                                     id='test-subpart-selection'
-                                 )
-                             ])
-                ])
-            ])
+            ]),
+            dcc.Store(
+                id='coverage-storage',
+                data=initialCov
+            ),
+            dcc.Store(
+                id='clear-coverage',
+                data=0
+            ),
+            dcc.Store(
+                id='current-sequence',
+                data=0
+            )
+        ])
     ])
 
 
@@ -497,6 +509,8 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
         state=[State('current-sequence', 'data')]
     )
     def signal_sequence_updated(_, current):
+        if current is None:
+            return 0
         return current + 1
 
     # whether or not to clear the coverage, based on a

--- a/tests/dashbio_demos/app_sequence_viewer.py
+++ b/tests/dashbio_demos/app_sequence_viewer.py
@@ -157,7 +157,23 @@ def layout():
                     value='what-is',
                     children=html.Div(className='seq-view-tab', children=[
                         html.H4('What is Sequence Viewer?'),
-                        html.P(description())
+                        html.P('Sequence Viewer is a component that allows you '
+                               'to display genomic and proteomic sequences. In '
+                               'this app, you can choose to view one of the preloaded '
+                               'data sets or upload your own FASTA file in the "Data" '
+                               'tab. For FASTA files with multiple entries, the entry '
+                               'to display in the component can be selected in the '
+                               '"Sequence" tab.'),
+                        html.P('In the "Sequence" tab, you can also select a region '
+                               'of the sequence to highlight and view its amino '
+                               'acid composition in the box under the component. '),
+                        html.P('You can additionally create a sequence coverage '
+                               '(i.e., a collection of subsequences to highlight '
+                               'and annotate). These subsequences can be extracted '
+                               'from your mouse selection, or from the results of the '
+                               'search that is shown in the component. Upon clicking on '
+                               'a coverage entry, you will be able to see the '
+                               'annotation that you have provided.'),
                     ])
                 ),
                 dcc.Tab(
@@ -276,7 +292,7 @@ def layout():
                                             'value': 'cov'
                                         }
                                     ],
-                                    value='cov'
+                                    value='sel'
                                 )
                             ]
                         ),

--- a/tests/dashbio_demos/app_sequence_viewer.py
+++ b/tests/dashbio_demos/app_sequence_viewer.py
@@ -243,16 +243,17 @@ def layout():
                                     "View entry:",
                                     className='seq-view-controls-name'
                                 ),
-                                html.Div(
-                                    id='seq-view-number-entries'
-                                ),
                                 dcc.Dropdown(
                                     id='fasta-entry-dropdown',
                                     options=[
                                         {'label': 1, 'value': 0}
                                     ],
                                     value=0
+                                ),
+                                html.Div(
+                                    id='seq-view-number-entries'
                                 )
+
                             ]
                         ),
                         html.Br(),
@@ -260,18 +261,18 @@ def layout():
                             id='seq-view-sel-or-cov-container',
                             children=[
                                 html.Div(
-                                    "Selection or coverage",
+                                    "Selection or coverage:",
                                     className='seq-view-controls-name'
                                 ),
                                 dcc.RadioItems(
                                     id='selection-or-coverage',
                                     options=[
                                         {
-                                            'label': 'Enable selection',
+                                            'label': 'selection',
                                             'value': 'sel'
                                         },
                                         {
-                                            'label': 'Enable coverage',
+                                            'label': 'coverage',
                                             'value': 'cov'
                                         }
                                     ],
@@ -337,10 +338,10 @@ def layout():
                             ),
                         ]),
 
-                        html.Div(
-                            id='seq-view-sel-slider-container',
+                        html.Div(id='seq-view-sel-slider-container',
                             children=[
-                                "Selection region",
+                                html.Div(className='seq-view-controls-name',
+                                         children="Selection region:"),
                                 dcc.RadioItems(
                                     id='sel-slider-or-input',
                                     options=[
@@ -360,6 +361,7 @@ def layout():
                                 html.Div(
                                     id='sel-region-inputs',
                                     children=[
+                                        "From: ",
                                         dcc.Input(
                                             id='sel-region-low',
                                             type='number',
@@ -367,6 +369,7 @@ def layout():
                                             max=0,
                                             placeholder="low"
                                         ),
+                                        "To: ",
                                         dcc.Input(
                                             id='sel-region-high',
                                             type='number',
@@ -374,8 +377,6 @@ def layout():
                                             max=0,
                                             placeholder="high"
                                         ),
-                                        html.Button(id='submit-sel-region',
-                                                    children="Submit")
                                     ],
                                     style={'display': 'none'}
                                 ),
@@ -385,7 +386,10 @@ def layout():
                                 html.Div(
                                     id='seq-view-dna-or-protein-container',
                                     children=[
-                                        "Translate from",
+                                        html.Div(
+                                            className='seq-view-controls-name',
+                                            children="Translate selection from:"
+                                        ),
                                         dcc.Dropdown(
                                             id='translation-alphabet',
                                             options=[
@@ -400,7 +404,11 @@ def layout():
                                 ),
 
                                 html.Br(),
-                                "Color",
+
+                                html.Div(
+                                    className='seq-view-controls-name',
+                                    children="Selection highlight color:"
+                                ),
                                 dcc.Dropdown(
                                     id='sel-color',
                                     options=[
@@ -413,24 +421,26 @@ def layout():
                                         {'label': 'red', 'value': 'red'}
                                     ],
                                     value='indigo'
-                                ),
+                                )
                             ]
                         )
-                    ]),
+                    ]
+                ),
+
             ]),
-            dcc.Store(
-                id='coverage-storage',
-                data=initialCov
-            ),
-            dcc.Store(
-                id='clear-coverage',
-                data=0
-            ),
-            dcc.Store(
-                id='current-sequence',
-                data=0
-            )
-        ])
+        ]),
+        dcc.Store(
+            id='coverage-storage',
+            data=initialCov
+        ),
+        dcc.Store(
+            id='clear-coverage',
+            data=0
+        ),
+        dcc.Store(
+            id='current-sequence',
+            data=0
+        )
     ])
 
 
@@ -651,13 +661,6 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
         return 0
 
     @app.callback(
-        Output('sel-region-high', 'min'),
-        [Input('sel-region-low', 'value')]
-    )
-    def lower_bound(low_val):
-        return low_val
-
-    @app.callback(
         Output('sel-region-high', 'value'),
         [Input('sequence-viewer', 'sequence')]
     )
@@ -667,23 +670,24 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
     @app.callback(
         Output('sequence-viewer', 'selection'),
         [Input('sel-slider', 'value'),
-         Input('submit-sel-region', 'n_clicks'),
+         Input('sel-region-low', 'value'),
+         Input('sel-region-high', 'value'),
          Input('selection-or-coverage', 'value'),
          Input('sel-color', 'value')],
-        state=[State('sel-slider-or-input', 'value'),
-               State('sel-region-low', 'value'),
-               State('sel-region-high', 'value')]
+        state=[State('sel-slider-or-input', 'value')]
     )
     def update_sel(
             slider_value,
-            _,
+            sel_low,
+            sel_high,
             sel_or_cov,
             color,
             slider_input,
-            sel_low,
-            sel_high
     ):
         answer = []
+        if sel_low > sel_high:
+            sel_low = 0
+            sel_high = 0
         if sel_or_cov != 'sel':
             answer = []
         else:

--- a/tests/dashbio_demos/app_sequence_viewer.py
+++ b/tests/dashbio_demos/app_sequence_viewer.py
@@ -276,7 +276,7 @@ def layout():
                                             'value': 'cov'
                                         }
                                     ],
-                                    value='sel'
+                                    value='cov'
                                 )
                             ]
                         ),
@@ -286,43 +286,61 @@ def layout():
 
                         html.Div(id='cov-options', children=[
                             html.Div(
-                                "Add coverage",
-                                style={'font-weight': 'bold'}
+                                "Add coverage from selection by:",
+                                className='seq-view-controls-name'
                             ),
                             dcc.RadioItems(
                                 id='mouse-sel-or-subpart-sel',
                                 options=[
-                                    {'label': 'Use mouse selection',
+                                    {'label': 'mouse',
                                      'value': 'mouse'},
-                                    {'label': 'Use subpart selection',
+                                    {'label': 'search',
                                      'value': 'subpart'}
                                 ],
                                 value='mouse'
                             ),
+
                             html.Br(),
-                            'Text color: ',
+
+                            html.Div(
+                                "Text color:",
+                                className='seq-view-controls-name'
+                            ),
                             dcc.Input(
                                 id='coverage-color',
                                 type='text',
                                 value='rgb(255, 0, 0)'
                             ),
-                            'Background color: ',
+                            html.Br(),
+                            html.Div(
+                                "Background color:",
+                                className='seq-view-controls-name'
+                            ),
                             dcc.Input(
                                 id='coverage-bg-color',
                                 type='text',
                                 value='rgb(0, 0, 255)'
                             ),
-                            'Tooltip: ',
+                            html.Br(),
+                            html.Div(
+                                "Tooltip:",
+                                className='seq-view-controls-name'
+                            ),
                             dcc.Input(
                                 id='coverage-tooltip',
                                 type='text',
                                 value='',
                                 placeholder='hover text'
                             ),
+                            html.Br(),
+                            html.Div(
+                                "Underscore text: ",
+                                className='seq-view-controls-name'
+                            ),
                             dcc.Checklist(
                                 id='coverage-underscore',
                                 options=[
-                                    {'label': 'underscore text',
+                                    {'label': '',
                                      'value': 'underscore'}
                                 ],
                                 values=[]
@@ -338,8 +356,7 @@ def layout():
                             ),
                         ]),
 
-                        html.Div(id='seq-view-sel-slider-container',
-                            children=[
+                        html.Div(id='seq-view-sel-slider-container', children=[
                                 html.Div(className='seq-view-controls-name',
                                          children="Selection region:"),
                                 dcc.RadioItems(

--- a/tests/dashbio_demos/app_sequence_viewer.py
+++ b/tests/dashbio_demos/app_sequence_viewer.py
@@ -55,7 +55,7 @@ initialCov = [
 
 def header_colors():
     return {
-        'bg_color': '#2b69fb',
+        'bg_color': '#C50063',
         'font_color': 'white'
     }
 
@@ -86,7 +86,7 @@ def layout():
                         html.Div(id='seq-view-info-desc',
                                  children=[
                                      html.Span(
-                                         "Description: ",
+                                         "Description",
                                          className='seq-view-info-element-title'
                                      ),
                                      html.Div(
@@ -100,7 +100,7 @@ def layout():
                         html.Div(id='seq-view-info-aa-comp',
                                  children=[
                                      html.Span(
-                                         "Amino acid composition: ",
+                                         "Amino acid composition",
                                          className='seq-view-info-element-title'
                                      ),
                                      html.Div(
@@ -113,7 +113,7 @@ def layout():
                         html.Div(id='seq-view-info-coverage-clicked',
                                  children=[
                                      html.Span(
-                                         "Coverage entry clicked: ",
+                                         "Coverage entry clicked",
                                          className='seq-view-info-element-title'
                                      ),
                                      html.Div(
@@ -126,7 +126,7 @@ def layout():
                         html.Div(id='seq-view-info-mouse-selection',
                                  children=[
                                      html.Span(
-                                         "Mouse selection: ",
+                                         "Mouse selection",
                                          className='seq-view-info-element-title'
                                      ),
                                      html.Div(
@@ -138,7 +138,7 @@ def layout():
 
                         html.Div(id='seq-view-info-subpart-sel', children=[
                             html.Span(
-                                "Subpart selected: ",
+                                "Subpart selected",
                                 className='seq-view-info-element-title'
                             ),
                             html.Div(
@@ -412,7 +412,7 @@ def layout():
                                         {'label': 'orange', 'value': 'orange'},
                                         {'label': 'red', 'value': 'red'}
                                     ],
-                                    value='blue'
+                                    value='indigo'
                                 ),
                             ]
                         )


### PR DESCRIPTION
## About 
Sequence viewer app redesign. 

## Description of changes 
* Move all controls to `dcc.Tabs` 
* Move sequence info underneath sequence viewer component and group the two in a single parent div 
* Fix heights of both sequence info container and sequence viewer component container
* Change accent colour 

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


