### PR TITLE
Add preset group:all to Renovate config.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,20 @@
   ],
   "enabledManagers": [
     "npm"
-  ]
+  ],
+  "groupName": "all dependencies",
+  "separateMajorMinor": false,
+  "groupSlug": "all",
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "groupName": "all dependencies",
+      "groupSlug": "all"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Closes #240 

## About 
This is about dependency management.

## Description of changes 
We are grouping the automated dependency updates into a single PR (from the Renovate Bot).
So from tomorrow onwards, we can review them all at once.
Reference: https://renovatebot.com/docs/presets-group/

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)