### PR TITLE
Exclude ideogram from Renovate updates.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,8 @@
   ],
   "lockFileMaintenance": {
     "enabled": false
-  }
+  },
+  "packageRules": [{
+    "excludePackageNames": ["ideogram"]
+  }]
 }


### PR DESCRIPTION
## About 
This is about dependency management. Taking care of one thing at a time... as per https://github.com/plotly/dash-bio/pull/262#issuecomment-475241271

## Description of changes
See PR title.
Reference: https://renovatebot.com/docs/configuration-options/#excludepackagenames

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)