### PR TITLE
Exclude react-* packages from Renovate updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
     "node":
         docker:
-            - image: circleci/node:8.11.3
+            - image: circleci/node:11.10.1
 
         steps:
             - checkout

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,9 @@
   "lockFileMaintenance": {
     "enabled": false
   },
+    "packageRules": [{
+      "excludePackagePatterns": ["react-*"]
+  }],
   "ignoreDeps": [
     "ideogram",
     "react"


### PR DESCRIPTION
Addresses https://github.com/plotly/dash-bio/pull/272#issuecomment-475899788.

## About 
This is about dependency management.

## Description of changes
Reference: https://renovatebot.com/docs/configuration-options/#excludepackagepatterns

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


