### PR TITLE
Tell Renovate to ignore react deps explicitly.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,9 +14,6 @@
       "packagePatterns": [
         "*"
       ],
-      "excludePackagePatterns": [
-        "react-*"
-      ],
       "groupName": "all dependencies",
       "groupSlug": "all"
     }
@@ -26,6 +23,8 @@
   },
   "ignoreDeps": [
     "ideogram",
-    "react"
+    "react",
+    "react-dom",
+    "react-docgen"
   ]
 }


### PR DESCRIPTION
## About 
In light of #281, I wasn't able to use `excludePackagePatterns` in the Renovate config.

## Description of changes 
So I'm suggesting a small change, which has worked so far in terms of ignoring updates for React and Ideogram. Thanks @Marc-Andre-Rivet for bearing with all my questions!

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


