### PR TITLE
Dash renderer update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Changed property `fullChromosomeLabels` so that it can be updated using dash callbacks
 * Changed Imputer (deprecated) to SimpleImputer in Clustergram component.
 * Changed property name `impute_function` to `imputer_parameters` in Clustergram component.
+* Changed install requirement to Dash version 0.40.0 or greater.
 
 ### Added
 * Added ability to define custom colours in styles parser for Molecule3D.

--- a/dash_bio/AlignmentChart.py
+++ b/dash_bio/AlignmentChart.py
@@ -112,26 +112,3 @@ are set."""
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')
         super(AlignmentChart, self).__init__(**args)
-
-    def __repr__(self):
-        if(any(getattr(self, c, None) is not None
-               for c in self._prop_names
-               if c is not self._prop_names[0])
-           or any(getattr(self, c, None) is not None
-                  for c in self.__dict__.keys()
-                  if any(c.startswith(wc_attr)
-                  for wc_attr in self._valid_wildcard_attributes))):
-            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self._prop_names
-                                      if getattr(self, c, None) is not None])
-            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self.__dict__.keys()
-                                      if any([c.startswith(wc_attr)
-                                      for wc_attr in
-                                      self._valid_wildcard_attributes])])
-            return ('AlignmentChart(' + props_string +
-                   (', ' + wilds_string if wilds_string != '' else '') + ')')
-        else:
-            return (
-                'AlignmentChart(' +
-                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_bio/AlignmentViewer.py
+++ b/dash_bio/AlignmentViewer.py
@@ -112,26 +112,3 @@ are set."""
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')
         super(AlignmentViewer, self).__init__(**args)
-
-    def __repr__(self):
-        if(any(getattr(self, c, None) is not None
-               for c in self._prop_names
-               if c is not self._prop_names[0])
-           or any(getattr(self, c, None) is not None
-                  for c in self.__dict__.keys()
-                  if any(c.startswith(wc_attr)
-                  for wc_attr in self._valid_wildcard_attributes))):
-            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self._prop_names
-                                      if getattr(self, c, None) is not None])
-            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self.__dict__.keys()
-                                      if any([c.startswith(wc_attr)
-                                      for wc_attr in
-                                      self._valid_wildcard_attributes])])
-            return ('AlignmentViewer(' + props_string +
-                   (', ' + wilds_string if wilds_string != '' else '') + ')')
-        else:
-            return (
-                'AlignmentViewer(' +
-                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_bio/Circos.py
+++ b/dash_bio/Circos.py
@@ -57,26 +57,3 @@ please check the docs."""
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')
         super(Circos, self).__init__(**args)
-
-    def __repr__(self):
-        if(any(getattr(self, c, None) is not None
-               for c in self._prop_names
-               if c is not self._prop_names[0])
-           or any(getattr(self, c, None) is not None
-                  for c in self.__dict__.keys()
-                  if any(c.startswith(wc_attr)
-                  for wc_attr in self._valid_wildcard_attributes))):
-            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self._prop_names
-                                      if getattr(self, c, None) is not None])
-            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self.__dict__.keys()
-                                      if any([c.startswith(wc_attr)
-                                      for wc_attr in
-                                      self._valid_wildcard_attributes])])
-            return ('Circos(' + props_string +
-                   (', ' + wilds_string if wilds_string != '' else '') + ')')
-        else:
-            return (
-                'Circos(' +
-                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_bio/Ideogram.py
+++ b/dash_bio/Ideogram.py
@@ -165,26 +165,3 @@ e.g., for mitochondrial (MT) and chloroplast (CP) DNA."""
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')
         super(Ideogram, self).__init__(**args)
-
-    def __repr__(self):
-        if(any(getattr(self, c, None) is not None
-               for c in self._prop_names
-               if c is not self._prop_names[0])
-           or any(getattr(self, c, None) is not None
-                  for c in self.__dict__.keys()
-                  if any(c.startswith(wc_attr)
-                  for wc_attr in self._valid_wildcard_attributes))):
-            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self._prop_names
-                                      if getattr(self, c, None) is not None])
-            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self.__dict__.keys()
-                                      if any([c.startswith(wc_attr)
-                                      for wc_attr in
-                                      self._valid_wildcard_attributes])])
-            return ('Ideogram(' + props_string +
-                   (', ' + wilds_string if wilds_string != '' else '') + ')')
-        else:
-            return (
-                'Ideogram(' +
-                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_bio/Molecule3dViewer.py
+++ b/dash_bio/Molecule3dViewer.py
@@ -42,26 +42,3 @@ Those keys have the following types:
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')
         super(Molecule3dViewer, self).__init__(**args)
-
-    def __repr__(self):
-        if(any(getattr(self, c, None) is not None
-               for c in self._prop_names
-               if c is not self._prop_names[0])
-           or any(getattr(self, c, None) is not None
-                  for c in self.__dict__.keys()
-                  if any(c.startswith(wc_attr)
-                  for wc_attr in self._valid_wildcard_attributes))):
-            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self._prop_names
-                                      if getattr(self, c, None) is not None])
-            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self.__dict__.keys()
-                                      if any([c.startswith(wc_attr)
-                                      for wc_attr in
-                                      self._valid_wildcard_attributes])])
-            return ('Molecule3dViewer(' + props_string +
-                   (', ' + wilds_string if wilds_string != '' else '') + ')')
-        else:
-            return (
-                'Molecule3dViewer(' +
-                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_bio/NeedlePlot.py
+++ b/dash_bio/NeedlePlot.py
@@ -51,26 +51,3 @@ Those keys have the following types:
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')
         super(NeedlePlot, self).__init__(**args)
-
-    def __repr__(self):
-        if(any(getattr(self, c, None) is not None
-               for c in self._prop_names
-               if c is not self._prop_names[0])
-           or any(getattr(self, c, None) is not None
-                  for c in self.__dict__.keys()
-                  if any(c.startswith(wc_attr)
-                  for wc_attr in self._valid_wildcard_attributes))):
-            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self._prop_names
-                                      if getattr(self, c, None) is not None])
-            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self.__dict__.keys()
-                                      if any([c.startswith(wc_attr)
-                                      for wc_attr in
-                                      self._valid_wildcard_attributes])])
-            return ('NeedlePlot(' + props_string +
-                   (', ' + wilds_string if wilds_string != '' else '') + ')')
-        else:
-            return (
-                'NeedlePlot(' +
-                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_bio/OncoPrint.py
+++ b/dash_bio/OncoPrint.py
@@ -60,26 +60,3 @@ Will disable auto-resizing of plots if set."""
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')
         super(OncoPrint, self).__init__(**args)
-
-    def __repr__(self):
-        if(any(getattr(self, c, None) is not None
-               for c in self._prop_names
-               if c is not self._prop_names[0])
-           or any(getattr(self, c, None) is not None
-                  for c in self.__dict__.keys()
-                  if any(c.startswith(wc_attr)
-                  for wc_attr in self._valid_wildcard_attributes))):
-            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self._prop_names
-                                      if getattr(self, c, None) is not None])
-            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self.__dict__.keys()
-                                      if any([c.startswith(wc_attr)
-                                      for wc_attr in
-                                      self._valid_wildcard_attributes])])
-            return ('OncoPrint(' + props_string +
-                   (', ' + wilds_string if wilds_string != '' else '') + ')')
-        else:
-            return (
-                'OncoPrint(' +
-                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_bio/SequenceViewer.py
+++ b/dash_bio/SequenceViewer.py
@@ -76,26 +76,3 @@ Those keys have the following types:
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')
         super(SequenceViewer, self).__init__(**args)
-
-    def __repr__(self):
-        if(any(getattr(self, c, None) is not None
-               for c in self._prop_names
-               if c is not self._prop_names[0])
-           or any(getattr(self, c, None) is not None
-                  for c in self.__dict__.keys()
-                  if any(c.startswith(wc_attr)
-                  for wc_attr in self._valid_wildcard_attributes))):
-            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self._prop_names
-                                      if getattr(self, c, None) is not None])
-            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self.__dict__.keys()
-                                      if any([c.startswith(wc_attr)
-                                      for wc_attr in
-                                      self._valid_wildcard_attributes])])
-            return ('SequenceViewer(' + props_string +
-                   (', ' + wilds_string if wilds_string != '' else '') + ')')
-        else:
-            return (
-                'SequenceViewer(' +
-                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/dash_bio/Speck.py
+++ b/dash_bio/Speck.py
@@ -61,26 +61,3 @@ and licorice"""
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')
         super(Speck, self).__init__(**args)
-
-    def __repr__(self):
-        if(any(getattr(self, c, None) is not None
-               for c in self._prop_names
-               if c is not self._prop_names[0])
-           or any(getattr(self, c, None) is not None
-                  for c in self.__dict__.keys()
-                  if any(c.startswith(wc_attr)
-                  for wc_attr in self._valid_wildcard_attributes))):
-            props_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self._prop_names
-                                      if getattr(self, c, None) is not None])
-            wilds_string = ', '.join([c+'='+repr(getattr(self, c, None))
-                                      for c in self.__dict__.keys()
-                                      if any([c.startswith(wc_attr)
-                                      for wc_attr in
-                                      self._valid_wildcard_attributes])])
-            return ('Speck(' + props_string +
-                   (', ' + wilds_string if wilds_string != '' else '') + ')')
-        else:
-            return (
-                'Speck(' +
-                repr(getattr(self, self._prop_names[0], None)) + ')')

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ dash-bio==0.0.8rc13
 dash-core-components==0.43.1
 dash-daq==0.1.4
 dash-html-components==0.13.5
-dash-table==3.4.0
 gunicorn
 jsonschema
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,11 @@
 biopython
 colour==0.1.5
 cython>=0.19
-dash==0.37.0
+dash>=0.40.0
 dash-bio==0.0.8rc13
 dash-core-components==0.43.1
 dash-daq==0.1.4
 dash-html-components==0.13.5
-dash-renderer==0.18.0
 dash-table==3.4.0
 gunicorn
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@ colour==0.1.5
 cython>=0.19
 dash>=0.40.0
 dash-bio==0.0.8rc13
-dash-core-components==0.43.1
 dash-daq==0.1.4
-dash-html-components==0.13.5
 gunicorn
 jsonschema
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         'biopython',
         'colour',
         'dash>=0.40.0',
-        'dash-html-components',
         'pandas',
         'parmed',
         'plotly',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         'biopython',
         'colour',
-        'dash>=0.37.0',
+        'dash>=0.40.0',
         'dash-html-components',
         'pandas',
         'parmed',

--- a/tests/dashbio_demos/app_alignment_viewer.py
+++ b/tests/dashbio_demos/app_alignment_viewer.py
@@ -104,11 +104,11 @@ def layout():
         html.Div([
             html.Div(id='alignment-control-tabs', children=[
                 dcc.Tabs(
-                    id='alignment-tabs',
+                    id='alignment-tabs', value='what-is',
                     children=[
                         dcc.Tab(
                             label='About',
-                            value='alignment-tab-about',
+                            value='what-is',
                             children=html.Div(className='alignment-tab', children=[
                                 html.H4(
                                     "What is Alignment Viewer?"

--- a/tests/dashbio_demos/app_circos.py
+++ b/tests/dashbio_demos/app_circos.py
@@ -922,7 +922,7 @@ def layout():
         ),
 
         html.Div(id='circos-control-tabs', children=[
-            dcc.Tabs(id='circos-tabs', children=[
+            dcc.Tabs(id='circos-tabs', value='what-is', children=[
                 dcc.Tab(
                     label='About',
                     value='what-is',

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -125,7 +125,7 @@ def layout():
         ),
 
         html.Div(id='clustergram-control-tabs', children=[
-            dcc.Tabs(id='clustergram-tabs', children=[
+            dcc.Tabs(id='clustergram-tabs', value='what-is', children=[
                 dcc.Tab(
                     label='About',
                     value='what-is',

--- a/tests/dashbio_demos/app_ideogram.py
+++ b/tests/dashbio_demos/app_ideogram.py
@@ -426,7 +426,7 @@ def layout():
     return html.Div(id='ideogram-body', children=[
         html.Div(id='ideogram-container'),
         html.Div(id='ideogram-control-tabs', children=[
-            dcc.Tabs(id='ideogram-tabs', children=[
+            dcc.Tabs(id='ideogram-tabs', value='what-is', children=[
                 dcc.Tab(
                     label='About',
                     value='what-is',

--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -53,7 +53,7 @@ def layout():
         ),
 
         html.Div(id='manhattan-control-tabs', children=[
-            dcc.Tabs(id='manhattan-tabs', children=[
+            dcc.Tabs(id='manhattan-tabs', value='what-is', children=[
                 dcc.Tab(
                     label='About',
                     value='what-is',

--- a/tests/dashbio_demos/app_molecule3d.py
+++ b/tests/dashbio_demos/app_molecule3d.py
@@ -41,11 +41,10 @@ def layout():
     return html.Div(
         id="mol3d-body",
         children=[
-
             html.Div(
                 id='mol3d-control-tabs',
                 children=[
-                    dcc.Tabs([
+                    dcc.Tabs(id='mol3d-tabs', value='what-is', children=[
                         dcc.Tab(
                             label='About',
                             value='what-is',
@@ -231,7 +230,6 @@ def layout():
                         ),
 
                     ]),
-                    html.Div(id='mol3d-tabs-content')
                 ]),
 
             html.Div(

--- a/tests/dashbio_demos/app_needle_plot.py
+++ b/tests/dashbio_demos/app_needle_plot.py
@@ -120,7 +120,7 @@ def layout():
         ),
 
         html.Div(id='needleplot-control-tabs', children=[
-            dcc.Tabs(id='needleplot-tabs', children=[
+            dcc.Tabs(id='needleplot-tabs', value='what-is', children=[
                 dcc.Tab(
                     label='About',
                     value='what-is',

--- a/tests/dashbio_demos/app_sequence_viewer.py
+++ b/tests/dashbio_demos/app_sequence_viewer.py
@@ -151,7 +151,7 @@ def layout():
         ),
 
         html.Div(id='seq-view-control-tabs', children=[
-            dcc.Tabs(id='seq-view-tabs', children=[
+            dcc.Tabs(id='seq-view-tabs', value='what-is', children=[
                 dcc.Tab(
                     label='About',
                     value='what-is',

--- a/tests/dashbio_demos/app_speck.py
+++ b/tests/dashbio_demos/app_speck.py
@@ -236,14 +236,6 @@ def layout():
             id='speck-store-preset-atom-style',
             data=None
         ),
-        dcc.Store(
-            id='speck-view-updated',
-            data=None
-        ),
-
-        html.Div(
-            id='speck-idk'
-        )
     ])
 
 
@@ -266,13 +258,6 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
         if len(presets_enable) == 0:
             return {'display': 'none'}
         return {'display': 'inline-block'}
-
-    @app.callback(
-        Output('speck-view-updated', 'data'),
-        [Input('speck', 'view')]
-    )
-    def update_something(_):
-        return 'update'
 
     @app.callback(
         Output('speck', 'data'),

--- a/tests/dashbio_demos/app_speck.py
+++ b/tests/dashbio_demos/app_speck.py
@@ -134,7 +134,7 @@ def layout():
         ),
 
         html.Div(id='speck-control-tabs', children=[
-            dcc.Tabs(id='speck-tabs', children=[
+            dcc.Tabs(id='speck-tabs', value='what-is', children=[
                 dcc.Tab(
                     label='About',
                     value='what-is',

--- a/tests/dashbio_demos/sample_data/needle_mutations_data.json
+++ b/tests/dashbio_demos/sample_data/needle_mutations_data.json
@@ -1,0 +1,1 @@
+{"x": [], "y": [], "mutationGroups": [], "domains": []}

--- a/tests/dashbio_demos/sample_data/needle_mutations_data.json
+++ b/tests/dashbio_demos/sample_data/needle_mutations_data.json
@@ -1,1 +1,0 @@
-{"x": [], "y": [], "mutationGroups": [], "domains": []}


### PR DESCRIPTION
(note that I am not publishing a new version of the package, since the problem with Speck's `view` prop from #241 still needs to be fixed)

## About 
Updates to `dash` and `dash-renderer` ensure that `setProps` does not have to be defined by creating a callback that takes the component as input. This fixes part of the issue referenced in #241. 

## Description of changes 
* Change the Dash version in the requirements for the demo apps and in the setup install requirements for Dash Bio. 
* Change the demo apps to have default tabs, as the newest version of `dash-core-components` does not display the contents of the first tab by default.
* Make the IDs for the tabs in each of the demo apps more uniform. 
* Remove unnecessary callback in Speck application.

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


