### PR TITLE
Clustergram improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [0.0.9]
 
+### Fixed
+* Fixed issue with Clustergram rows and columns reordering incorrectly
+  on the heatmap when precomputed traces are used to generate the
+  figure.
+
 ### Changed
 * Changed Clustergram to only return a figure by default, so that
   values no longer need to be unpacked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   values no longer need to be unpacked.
 
 ### Added
-* Added to Clustergram the ability to generate a "curves dictionary"
+* Added to Clustergram the ability to generate a "curve dictionary"
 to translate curve number (available in hoverData/clickData) to the
 row or column cluster it represents on the graph.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## [0.0.8]
+## [0.0.9]
+
+### Changed
+* Changed Clustergram to only return a figure by default, so that
+  values no longer need to be unpacked.
+
+### Added
+* Added to Clustergram the ability to generate a "curves dictionary"
+to translate curve number (available in hoverData/clickData) to the
+row or column cluster it represents on the graph.
+
+## [0.0.8] - 2019-01-04
 
 ### Fixed
 * Fixed issue with Clustergram not reordering rows and columns after clustering.

--- a/assets/clustergram-style.css
+++ b/assets/clustergram-style.css
@@ -1,5 +1,5 @@
 #clustergram-body {
-    font-family: 'Open Sans Light', sans-serif;
+    font-family: sans-serif;
     padding: 5px;
     background-color: #191A1C;
     color: #dddddd;
@@ -39,9 +39,10 @@
 }
 
 .clustergram-tab {
-    max-height: 460px;
+    height: 420px;
+    margin: 15px;
     overflow-y: auto;
-    padding-right: 15px;
+    padding-right: 20px;
 }
 
 #clustergram-control-tabs .Select-control {
@@ -96,9 +97,9 @@
 }
 
 #clustergram-body .rc-slider {
-    width: 250px;
+    width: 225px;
     float: right;
-    margin-top: -15px;
+    margin-top: -17px;
 }
 
 #clustergram-body .rc-slider-track {
@@ -176,6 +177,14 @@ input#selected-rows, input#selected-columns {
     margin-right:10px;
 }
 
+#clustergram-body h3 {
+    font-size: 24pt !important;
+    text-align: center !important;
+}
+#clustergram-body p {
+    font-weight: 200 !important;
+    font-size: 10pt !important;
+}
 #row-or-col-group, input#annotation {
     margin-top: 5px !important;
     margin-bottom: 30px !important;

--- a/assets/clustergram-style.css
+++ b/assets/clustergram-style.css
@@ -73,7 +73,23 @@
     border-bottom: none;
     color: #FFBF00;
 }
-
+#clustergram-annot-color, #clustergram-body .chrome-picker {
+    border: none !important;
+    background: none !important;
+    margin-bottom: 125px;
+}
+#clustergram-annot-color > div > div:nth-child(1) {
+    margin-bottom: -60px !important;
+}
+#clustergram-annot-color > div > div:nth-child(1) > div {
+    height: 120px;
+}
+#clustergram-annot-color > div > div:nth-child(2) > div:nth-child(2) {
+    display: none !important;
+}
+#clustergram-annot-color {
+    color: white !important;
+}
 #clustergram-body .Select-value-icon {
     color: #FFBF00;
     border-right: 1px solid #AAAAAA;
@@ -82,7 +98,7 @@
 #clustergram-body .rc-slider {
     width: 250px;
     float: right;
-    margin-top: 5px;
+    margin-top: -15px;
 }
 
 #clustergram-body .rc-slider-track {
@@ -107,22 +123,23 @@
     margin-top: 20px;
 }
 
-#clustergram-body #submit-group-marker, #clustergram-body #remove-all-group-markers {
-    float: left;
-    font-size:8pt !important;
-    padding: 0px;
-    margin-top: 10px;
-    margin-bottom: 40px;
+#clustergram-body #remove-all-group-markers {
+    float: right;
+    margin: 10px;
+    margin-bottom: 20px;
+    font-size:7pt !important;
+    line-height: 10pt;
+    padding: 0px !important;
     color: white;
     font-weight: 100;
     border-color: #FFBF00;
     text-align: center;
     width:48% !important;
+    height: 25px;
     transition-duration: 500ms;
 }
 
-
-#clustergram-body #submit-group-marker:hover, #clustergram-body #remove-all-group-markers:hover {
+#clustergram-body #remove-all-group-markers:hover {
     border-color: white;
 }
 
@@ -133,19 +150,22 @@
     margin-left: 2%;
 }
 
-#clustergram-body #group-number, #clustergram-body #color {
-    width: 48% !important;
+input#selected-rows, input#selected-columns {
+    padding: 0px !important;
 }
-#clustergram-body #group-number {
-    margin-right: 2% !important;
+
+#cluster-checklist, #hide-labels {
+    width: 200px;
+    float: right;
+    display: inline-block;
+    margin-top: 0px;
 }
-#clustergram-body #color {
-    margin-left: 2% !important;
+#cluster-checklist .Select-multi-value-wrapper, #hide-labels .Select-multi-value-wrapper {
+    margin-bottom: -5px;
 }
 
 #selected-rows .Select-control, #selected-columns .Select-control {
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding: 10px 0px;
 }
 #selected-rows .Select-multi-value-wrapper, #selected-columns .Select-multi-value-wrapper {
     max-height: 100px;
@@ -156,20 +176,9 @@
     margin-right:10px;
 }
 
-input#selected-rows, input#selected-columns {
-    padding: 0px !important;
-}
-
-#cluster-checklist, #hide-labels {
-    width: 70%;
-    float: right;
-    display: inline-block;
-    margin-top: 5px;
-}
-
 #row-or-col-group, input#annotation {
     margin-top: 5px !important;
-    margin-bottom: 5px !important;
+    margin-bottom: 30px !important;
 }
 
 #clustergram-body input {
@@ -214,8 +223,25 @@ input#selected-rows, input#selected-columns {
 }
 .clustergram-option-name {
     font-size: 13pt;
-    margin-bottom: 10px;
+    padding-bottom: 20px;
     margin-top: 10px;
     font-weight: 100 !important;
     display: inline-block;
+
+}
+.clustergram-option-name:after {
+    content: '';
+    width: 100%;
+    margin-bottom: 20px;
+}
+.clustergram-option-desc {
+    width: 90%;
+    margin-left: 5%;
+    font-size: 9pt;
+    margin-bottom: 30px;
+}
+.clustergram-option-desc:after {
+    content: '';
+    width: 100%;
+    margin-bottom: 20px;
 }

--- a/dash_bio/component_factory/_clustergram.py
+++ b/dash_bio/component_factory/_clustergram.py
@@ -850,8 +850,8 @@ Keyword arguments:
     def _compute_clustered_data(
             self
     ):
-        """Gets the traces that need to be plotted for the row and column
-        dendrograms, and updates the ordering of the 2D data array,
+        """Get the traces that need to be plotted for the row and column
+        dendrograms, and update the ordering of the 2D data array,
         row labels, and column labels to match the reordered
         dendrogram leaves.
 

--- a/dash_bio/component_factory/_clustergram.py
+++ b/dash_bio/component_factory/_clustergram.py
@@ -104,7 +104,7 @@ Keyword arguments:
     the dataset, the color on the heatmap would be white; all cells
     with a value in the 50th or higher percentile, excluding the 100th
     percentile, would be gray; and the cell(s) in the 100th percentile
-    would be colored black. (Default: [[0.0, 'rgb(255,0,0'], [0.5,
+    would be colored black. (Default: [[0.0, 'rgb(255,0,0)'], [0.5,
     'rgb(0,0,0)'], [1.0, 'rgb(0,255,0)']])
 - color_list (dict; optional): The list of colors to use for different
    clusters in the dendrogram that have a root under the threshold for
@@ -249,7 +249,7 @@ Keyword arguments:
     the dataset, the color on the heatmap would be white; all cells
     with a value in the 50th or higher percentile, excluding the 100th
     percentile, would be gray; and the cell(s) in the 100th percentile
-    would be colored black. (Default: [[0.0, 'rgb(255,0,0'], [0.5,
+    would be colored black. (Default: [[0.0, 'rgb(255,0,0)'], [0.5,
     'rgb(0,0,0)'], [1.0, 'rgb(0,255,0)']])
 - color_list (dict; optional): The list of colors to use for different
    clusters in the dendrogram that have a root under the threshold for

--- a/dash_bio/component_factory/_clustergram.py
+++ b/dash_bio/component_factory/_clustergram.py
@@ -193,7 +193,7 @@ Keyword arguments:
         return_values.append(ct)
 
     # return only the figure by default
-    if(len(return_values) == 1):
+    if len(return_values) == 1:
         return return_values[0]
 
     # otherwise, return all requested values

--- a/dash_bio/package.json
+++ b/dash_bio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.9-rc2",
+  "version": "0.0.9-rc3",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/dash_bio/package.json
+++ b/dash_bio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.9-rc1",
+  "version": "0.0.9-rc2",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/dash_bio/package.json
+++ b/dash_bio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.8",
+  "version": "0.0.9-rc1",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.8-rc13",
+  "version": "0.0.9-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5508,8 +5508,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5530,14 +5529,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5553,22 +5550,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5685,8 +5679,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5698,7 +5691,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5713,7 +5705,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5721,14 +5712,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5747,7 +5736,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5829,8 +5817,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5842,7 +5829,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5929,8 +5915,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5966,7 +5951,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5986,7 +5970,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6031,15 +6014,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.9-rc2",
+  "version": "0.0.9-rc3",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.9-rc1",
+  "version": "0.0.9-rc2",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.8",
+  "version": "0.0.9-rc1",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ biopython
 colour==0.1.5
 cython>=0.19
 dash>=0.40.0
-dash-bio==0.0.9-rc2
+dash-bio==0.0.9-rc3
 dash-daq==0.1.4
 gunicorn
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ biopython
 colour==0.1.5
 cython>=0.19
 dash>=0.40.0
-dash-bio==0.0.8
+dash-bio==0.0.9-rc1
 dash-daq==0.1.4
 gunicorn
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ biopython
 colour==0.1.5
 cython>=0.19
 dash>=0.40.0
-dash-bio==0.0.9-rc1
+dash-bio==0.0.9-rc2
 dash-daq==0.1.4
 gunicorn
 jsonschema

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -143,10 +143,10 @@ def layout():
                                'different colors if they comprise data points '
                                'that share some minimal level of correlation.'),
                         html.P('In the "Data" tab, you can select a preloaded '
-                               'dataset to display or, optionally, upload one '
+                               'dataset to display or, alternatively, upload one '
                                'of your own. A sample dataset is also available '
                                'for download in the tab.'),
-                        html.P('In the "Graph" tab,  you can choose the '
+                        html.P('In the "Graph" tab, you can choose the '
                                'dimension(s) along which clustering will be '
                                'performed (row or column). You can also change '
                                'the threshold that determines the point at which '
@@ -321,7 +321,7 @@ def layout():
                                 ),
                                 html.Br(),
                                 html.Div(className='clustergram-option-desc', children=[
-                                    'Annotate your heatmap by labelling clusters; '
+                                    'Annotate your heatmap by labeling clusters; '
                                     'choose a color for the annotation, as well as '
                                     'text for the annotation, below. Then, click '
                                     'on the row cluster or column cluster that you '

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -301,12 +301,12 @@ def layout():
                                     n_clicks_timestamp=0
                                 ),
                                 html.Br(),
-                                html.Div(className='clustergram-option-desc', children=
+                                html.Div(className='clustergram-option-desc', children=[
                                          'Annotate your heatmap by labelling clusters; '
                                          'choose a color for the annotation, as well as '
                                          'text for the annotation, below. Then, click '
                                          'on the row cluster or column cluster that you '
-                                         'wish to annotate.'),
+                                         'wish to annotate.']),
 
                                 daq.ColorPicker(
                                     id='clustergram-annot-color',

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -260,9 +260,6 @@ def layout():
 
                         html.Div(
                             id='threshold-wrapper',
-                            title='Annotate your heatmap by labelling clusters; ' +
-                            'hover over the clusters on the dendrogram to get their ' +
-                            'index.',
                             children=[
                                 'Column: ',
                                 dcc.Slider(
@@ -304,11 +301,11 @@ def layout():
                                 ),
                                 html.Br(),
                                 html.Div(className='clustergram-option-desc', children=[
-                                         'Annotate your heatmap by labelling clusters; '
-                                         'choose a color for the annotation, as well as '
-                                         'text for the annotation, below. Then, click '
-                                         'on the row cluster or column cluster that you '
-                                         'wish to annotate.']),
+                                    'Annotate your heatmap by labelling clusters; '
+                                    'choose a color for the annotation, as well as '
+                                    'text for the annotation, below. Then, click '
+                                    'on the row cluster or column cluster that you '
+                                    'wish to annotate.']),
 
                                 daq.ColorPicker(
                                     id='clustergram-annot-color',

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -135,7 +135,28 @@ def layout():
                     label='About',
                     value='what-is',
                     children=html.Div(className='clustergram-tab', children=[
-                        html.P('Gene expression data and heatmap with dendrogram.')
+                        html.H3('What is Clustergram?'),
+                        html.P('Clustergram is a combination of a heatmap and '
+                               'dendrograms that allows you to display '
+                               'hierarchical clustering data. '
+                               'Clusters on the dendrograms are highlighted in '
+                               'different colors if they comprise data points '
+                               'that share some minimal level of correlation.'),
+                        html.P('In the "Data" tab, you can select a preloaded '
+                               'dataset to display or, optionally, upload one '
+                               'of your own. A sample dataset is also available '
+                               'for download in the tab.'),
+                        html.P('In the "Graph" tab,  you can choose the '
+                               'dimension(s) along which clustering will be '
+                               'performed (row or column). You can also change '
+                               'the threshold that determines the point at which '
+                               'clusters are highlighted for the row and column '
+                               'dendrograms, and choose which rows and columns '
+                               'are used to compute the clustering.'),
+                        html.P('In addition, you can highlight specific clusters '
+                               'by adding annotations to the clustergram, and '
+                               'choose whether to show or hide the labels for the '
+                               'rows and/or columns.')
                     ])
                 ),
                 dcc.Tab(

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -130,7 +130,7 @@ def layout():
         ),
 
         html.Div(id='clustergram-control-tabs', children=[
-            dcc.Tabs(id='clustergram-tabs', value='graph', children=[
+            dcc.Tabs(id='clustergram-tabs', value='what-is', children=[
                 dcc.Tab(
                     label='About',
                     value='what-is',
@@ -287,7 +287,6 @@ def layout():
 
                         html.Div(
                             id='add-group-markers',
-                            title='',
                             children=[
                                 html.Div(
                                     className='clustergram-option-name',
@@ -622,6 +621,7 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
             computed_traces
     ):
         ctx = dash.callback_context
+        adding_grp_marker = ctx.triggered[0]['prop_id'].split('.')[0] == 'group-markers'
 
         wrapper_content = ''
         curves = None
@@ -678,8 +678,6 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
         if group_markers is not None:
             fig_opts['row_group_marker'] = group_markers['row_group_marker']
             fig_opts['col_group_marker'] = group_markers['col_group_marker']
-
-        adding_grp_marker = ctx.triggered[0]['prop_id'].split('.')[0] == 'group-markers'
 
         try:
             # don't recompute the dendrogram traces if we're just adding a group

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -322,8 +322,8 @@ def layout():
                                 html.Br(),
                                 html.Div(className='clustergram-option-desc', children=[
                                     'Annotate your heatmap by labeling clusters; '
-                                    'choose a color for the annotation, as well as '
-                                    'text for the annotation, below. Then, click '
+                                    'below, you can choose a color for the annotation, '
+                                    'as well as text for the annotation. Then, click '
                                     'on the row cluster or column cluster that you '
                                     'wish to annotate.']),
 

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -140,7 +140,7 @@ def layout():
                                'dendrograms that allows you to display '
                                'hierarchical clustering data. '
                                'Clusters on the dendrograms are highlighted in '
-                               'different colors if they comprise data points '
+                               'one color if they comprise data points '
                                'that share some minimal level of correlation.'),
                         html.P('In the "Data" tab, you can select a preloaded '
                                'dataset to display or, alternatively, upload one '
@@ -660,8 +660,9 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
             )
         if fig_opts['cluster'] is None:
             wrapper_content = html.Div(
-                'No clustering dimension has been selected to display. Please \
-                select at least one option from the dropdown.',
+                'No dimension has been selected along which to perform \
+                clustering. \
+                Please select at least one option from the dropdown.',
                 style={
                     'padding': '30px',
                     'font-size': '20pt'

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -679,7 +679,7 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
             fig_opts['col_group_marker'] = group_markers['col_group_marker']
 
         try:
-            fig, _ = dash_bio.Clustergram(
+            fig = dash_bio.Clustergram(
                 computed_traces=None,
                 data=data,
                 **fig_opts

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -648,7 +648,7 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
         curves = None
         comp_traces = computed_traces
 
-        if len(sel_rows) < 2 or len(sel_cols) < 2 or fig_opts is None:
+        if len(sel_rows) < 2 or len(sel_cols) < 2:
             wrapper_content = html.Div(
                 'No data have been selected to display. Please upload a file \
                 or select a preloaded file from the dropdown, then select at \
@@ -658,7 +658,8 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
                     'font-size': '20pt'
                 }
             )
-        if fig_opts['cluster'] is None:
+            return wrapper_content, curves, comp_traces
+        if fig_opts['cluster'] is None or len(fig_opts['cluster']) == 0:
             wrapper_content = html.Div(
                 'No dimension has been selected along which to perform \
                 clustering. \
@@ -668,6 +669,7 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
                     'font-size': '20pt'
                 }
             )
+            return wrapper_content, curves, comp_traces
 
         if dataset_name is not None:
             dataset = datasets[dataset_name]

--- a/tests/dashbio_demos/app_clustergram.py
+++ b/tests/dashbio_demos/app_clustergram.py
@@ -1,5 +1,7 @@
 import base64
 import os
+
+import dash
 from dash.dependencies import Input, Output, State
 import dash_core_components as dcc
 import dash_html_components as html
@@ -543,6 +545,11 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
     ):
         # remove all group markers, if necessary, or
         # initialize the group markers data
+        ctx = dash.callback_context
+        if ctx.triggered[0]['prop_id'].split('.')[0] == 'remove-all-group-markers':
+            return {'row_group_marker': [],
+                    'col_group_marker': []}
+
         if current_group_markers is None:
             current_group_markers = {'row_group_marker': [],
                                      'col_group_marker': []}
@@ -567,7 +574,6 @@ def callbacks(app):  # pylint: disable=redefined-outer-name
                 '{}_group_marker'.format(cluster_dimension)
             ].append(marker)
 
-        print(current_group_markers)
         return current_group_markers
 
     # description information


### PR DESCRIPTION
Addresses part of #288 

## Description of changes 
* Add ability in the Clustergram component to produce a dictionary that can translate the `clickData` from `dcc.Graph` into the cluster that was clicked.
* Add options to return the above dictionary, as well as an option to use precomputed traces, into the Clustergram component. Both of these are false by default. 
* Return *only* the figure data by default. This avoids the need to unpack values if one only wishes to display the clustergram.
* Add date to CHANGELOG for version `0.0.8`. 
* Refine and make use of the option to use precomputed traces in the demo application.

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


