### PR TITLE
Catch up 0.0.8 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.8-rc13",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This should have been part of #298 (diff came up as I ran `npm i`).