### PR TITLE
Build actual dash_bio node.js package in CI build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,18 @@ jobs:
                 command: npm run build:js
 
             - run:
+                name: "Create virtualenv"
+                command: |
+                    python -m venv venv
+
+            - run:
+                name: "Install Dash"
+                command: |
+                    . venv/bin/activate
+                    pip install --upgrade pip
+                    pip install dash==0.40.0
+
+            - run:
                 name: "Build Python package"
                 command: npm run build:py
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ jobs:
                 command: ./node_modules/.bin/eslint src
                 when: always
 
+            - run:
+                name: Build package
+                command: npm run build:all
+
 
     "python-3.6": &test-template
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,15 +43,12 @@ jobs:
                     python -m venv venv
 
             - run:
-                name: "Install Dash"
+                name: "Build Python package"
                 command: |
                     . venv/bin/activate
                     pip install --upgrade pip
                     pip install dash==0.40.0
-
-            - run:
-                name: "Build Python package"
-                command: npm run build:py
+                    npm run build:py
 
 
     "python-3.6": &test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,9 @@ jobs:
                 command: npm run build:js
 
             - run:
-                name: "Create virtualenv"
-                command: |
-                    python -m venv venv
-
-            - run:
                 name: "Build Python package"
                 command: |
+                    python -m venv venv
                     . venv/bin/activate
                     pip install --upgrade pip
                     pip install dash==0.40.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ jobs:
                 when: always
 
             - run:
-                name: Build package
-                command: npm run build:all
+                name: Build node.js package
+                command: npm run build:js
 
 
     "python-3.6": &test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
 
             - run:
                 name: "Build Node.js package"
-                command: npm run build:js
+                command: npm run build:js-dev
 
             - run:
                 name: "Build Python package"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,18 @@ version: 2
 jobs:
     "node":
         docker:
-            - image: circleci/node:11.10.1
+            - image: circleci/python:3.7-stretch-node
 
         steps:
             - checkout
+            - run:
+                name: "Update Node.js and npm"
+                command: |
+                  curl -sSL "https://nodejs.org/dist/v11.10.1/node-v11.10.1-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v11.10.1-linux-x64/bin/node
+                  curl https://www.npmjs.com/install.sh | sudo bash
+            - run:
+                name: Check current version of node
+                command: node -v
 
             - restore_cache:
                 key: deps1-{{ .Branch }}-{{ checksum "package.json" }}
@@ -26,8 +34,12 @@ jobs:
                 when: always
 
             - run:
-                name: Build node.js package
+                name: "Build Node.js package"
                 command: npm run build:js
+
+            - run:
+                name: "Build Python package"
+                command: npm run build:py
 
 
     "python-3.6": &test-template

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 biopython
 colour==0.1.5
 cython>=0.19
-dash>=0.40.0
+dash==0.40.0
 dash-bio==0.0.9-rc4
 dash-daq==0.1.4
 gunicorn


### PR DESCRIPTION
Closes #300. 

## About
We wanted to ensure that `dash_bio/bundle.js` builds successfully. This is now done, with the changes submitted here.

## Description of changes
I've added command `npm run build:js` to the "node" job, which runs in a node.js environment.

Ultimately, we may want to address the following warning:
![size_limit_warning](https://user-images.githubusercontent.com/2227806/55568425-f9da6700-56ff-11e9-9fe0-7ed599af3bab.png)

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)