### PR TITLE
Speck component rendering fix

### DIFF
--- a/dash_bio/package.json
+++ b/dash_bio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.9-rc3",
+  "version": "0.0.9-rc4",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.9-rc3",
+  "version": "0.0.9-rc4",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ biopython
 colour==0.1.5
 cython>=0.19
 dash>=0.40.0
-dash-bio==0.0.9-rc3
+dash-bio==0.0.9-rc4
 dash-daq==0.1.4
 gunicorn
 jsonschema

--- a/src/lib/components/Speck.react.js
+++ b/src/lib/components/Speck.react.js
@@ -137,10 +137,15 @@ export default class Speck extends Component {
         const aoResolution = 300;
         const renderer = new SpeckRenderer(canvas, resolution, aoResolution);
 
-        this.setState({
-            renderer: renderer,
-            refreshView: true,
-        }, function () { this.loadStructure(this.props.data) });
+        this.setState(
+            {
+                renderer: renderer,
+                refreshView: true,
+            },
+            function() {
+                this.loadStructure(this.props.data); // eslint-disable-line no-invalid-this
+            }
+        );
 
         // add event listeners
         const interactionHandler = new SpeckInteractions( // eslint-disable-line no-unused-vars

--- a/src/lib/components/Speck.react.js
+++ b/src/lib/components/Speck.react.js
@@ -140,7 +140,7 @@ export default class Speck extends Component {
         this.setState({
             renderer: renderer,
             refreshView: true,
-        });
+        }, function () { this.loadStructure(this.props.data) });
 
         // add event listeners
         const interactionHandler = new SpeckInteractions( // eslint-disable-line no-unused-vars


### PR DESCRIPTION
Closes #310 

## About 
- [ ] This is a new component 
- [ ] I am adding a feature to an existing component, or improving an existing feature
- [x] I am closing an issue 

## Description of changes 
This issue was due to the fact that `loadStructure` was not being called from `componentDidMount`, and instead only from `componentDidUpdate`. I also ran into an issue where `loadStructure` failed because  `this.state.renderer` was still `null`, even after having defined it -- this was because `setState` does not immediately mutate the state of the component (https://reactjs.org/docs/react-component.html#setstate). From the documentation: 

>`setState()` does not always immediately update the component. It may batch or defer the update until later. This makes reading `this.state` right after calling `setState()` a potential pitfall. Instead, use `componentDidUpdate` or a `setState` callback (`setState(updater, callback)`), either of which are guaranteed to fire after the update has been applied. If you need to set the state based on the previous state, read about the updater argument below.

I therefore added a callback to call `loadStructure()` only after the renderer had been updated to a non-null value. 

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


