### PR TITLE
Speck system fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
   figure.
 * Fixed issue with Speck not rendering unless it is attached to a callback.
 * Prevent Speck from trying to calculate a system with no atom.
-  which led to an error.
 
 ### Changed
 * Changed Clustergram to only return a figure by default, so that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,59 +6,72 @@
 * Fixed issue with Clustergram rows and columns reordering incorrectly
   on the heatmap when precomputed traces are used to generate the
   figure.
+* Fixed issue with Speck not rendering unless it is attached to a callback.
+* Fixed issue with Speck trying to calculate a system with no atoms,
+  which led to an error.
 
 ### Changed
 * Changed Clustergram to only return a figure by default, so that
   values no longer need to be unpacked.
 
 ### Added
-* Added to Clustergram the ability to generate a "curve dictionary"
-to translate curve number (available in hoverData/clickData) to the
-row or column cluster it represents on the graph.
+* Added to Clustergram the ability to generate a "curve dictionary" to
+  translate curve number (available in hoverData/clickData) to the row
+  or column cluster it represents on the graph.
 
 ## [0.0.8] - 2019-01-04
 
 ### Fixed
-* Fixed issue with Clustergram not reordering rows and columns after clustering.
+* Fixed issue with Clustergram not reordering rows and columns after
+  clustering.
 
 ### Removed
 * Removed mentions of Dash events in OncoPrint component.
 * Removed properties which weren't used in Ideogram component.
 
 ### Changed
-* Changed property `fullChromosomeLabels` so that it can be updated using dash callbacks
-* Changed Imputer (deprecated) to SimpleImputer in Clustergram component.
-* Changed property name `impute_function` to `imputer_parameters` in Clustergram component.
+* Changed property `fullChromosomeLabels` so that it can be updated
+  using dash callbacks.
+* Changed Imputer (deprecated) to SimpleImputer in Clustergram
+  component.
+* Changed property name `impute_function` to `imputer_parameters` in
+  Clustergram component.
 * Changed install requirement to Dash version 0.40.0 or greater.
 
 ### Added
-* Added ability to define custom colours in styles parser for Molecule3D.
+* Added ability to define custom colours in styles parser for
+  Molecule3D.
 
 ## [0.0.7] - 2019-26-02
 
 ### Changed
-* Changed unicode right arrow to greater-than sign in Circos for compatibility with Python 2.7.
+* Changed unicode right arrow to greater-than sign in Circos for
+  compatibility with Python 2.7.
 
 ## [0.0.6] - 2019-22-02
 
 ### Added
-* Added requirements from files in `utils`, as well as from pure-Python components, to setup install requirements.
+* Added requirements from files in `utils`, as well as from
+  pure-Python components, to setup install requirements.
 * Added more descriptive prop descriptions for Dash Ideogram.
 
 ## [0.0.5] - 2019-15-02
 
 ### Changed
-* Changed filenames in `dash_bio/utils/` folder to be snake case instead of camel case.
+* Changed filenames in `dash_bio/utils/` folder to be snake case
+  instead of camel case.
 
 ## [0.0.4] - 2019-11-02
 
 ### Added
-* Added recent update to Speck library to fix jumpy behavior on click-and-drag.
+* Added recent update to Speck library to fix jumpy behavior on
+  click-and-drag.
 
 ## [0.0.3] - 2019-06-02
 
 ### Added
-* Added variables to define strings used in `_volcano.py` graph labels.
+* Added variables to define strings used in `_volcano.py` graph
+  labels.
 
 ## [0.0.2] - 2019-05-02
 
@@ -66,4 +79,5 @@ row or column cluster it represents on the graph.
 * Fixed incompatibility issues with Dash `0.36.0`.
 
 ### Removed
-* Removed all mentions of `fireEvent` and anything else that used Dash events (which have been removed).
+* Removed all mentions of `fireEvent` and anything else that used Dash
+  events (which have been removed).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   on the heatmap when precomputed traces are used to generate the
   figure.
 * Fixed issue with Speck not rendering unless it is attached to a callback.
-* Fixed issue with Speck trying to calculate a system with no atoms,
+* Prevent Speck from trying to calculate a system with no atom.
   which led to an error.
 
 ### Changed
@@ -39,7 +39,7 @@
 * Changed install requirement to Dash version 0.40.0 or greater.
 
 ### Added
-* Added ability to define custom colours in styles parser for
+* Added ability to define custom colors in style parser for
   Molecule3D.
 
 ## [0.0.7] - 2019-26-02

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn tests.dashbio_demos.app_speck:server
+web: gunicorn index:server
 

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn index:server
+web: gunicorn tests.dashbio_demos.app_speck:server
 

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ import os
 #
 # This name MUST match the name that you specified in the
 # Dash App Manager
-DASH_APP_NAME = 'dash-speck'
+DASH_APP_NAME = 'dash-bio'
 # Set to 'private' if you want to add a login screen to your app
 # You can choose who can view the app in your list of files
 # at <your-plotly-server>/organize.

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ import os
 #
 # This name MUST match the name that you specified in the
 # Dash App Manager
-DASH_APP_NAME = 'dash-bio'
+DASH_APP_NAME = 'dash-speck'
 # Set to 'private' if you want to add a login screen to your app
 # You can choose who can view the app in your list of files
 # at <your-plotly-server>/organize.

--- a/dash_bio/package.json
+++ b/dash_bio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.9-rc4",
+  "version": "0.0.9-rc5",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.0.9-rc4",
+  "version": "0.0.9-rc5",
   "description": "Dash components for bioinformatics",
   "main": "build/index.js",
   "scripts": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ biopython
 colour==0.1.5
 cython>=0.19
 dash>=0.40.0
-dash-bio==0.0.9-rc4
+dash-bio==0.0.9-rc3
 dash-daq==0.1.4
 gunicorn
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 biopython
 colour==0.1.5
 cython>=0.19
-dash>=0.40.0
+dash==0.40.0
 dash-bio==0.0.9-rc5
 dash-daq==0.1.4
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ biopython
 colour==0.1.5
 cython>=0.19
 dash>=0.40.0
-dash-bio==0.0.9-rc3
+dash-bio==0.0.9-rc5
 dash-daq==0.1.4
 gunicorn
 jsonschema

--- a/src/lib/components/Speck.react.js
+++ b/src/lib/components/Speck.react.js
@@ -10,6 +10,11 @@ import {
 
 export default class Speck extends Component {
     loadStructure(data) {
+        // avoid trying to load an empty system
+        if (data.length === 0) {
+            return;
+        }
+
         const system = speckSystem.new();
 
         for (let i = 0; i < data.length; i++) {
@@ -18,6 +23,7 @@ export default class Speck extends Component {
             // add to the system
             speckSystem.addAtom(system, a.symbol, a.x, a.y, a.z);
         }
+
         speckSystem.center(system);
         speckSystem.calculateBonds(system);
 


### PR DESCRIPTION
## Description of changes 
Previously, the Speck component was trying to calculate the radius for an atom even if no atoms were present in the system. This led to an exception and a failure to render. 

Now, the function `loadStructure` simply returns if there are no atoms supplied in the system and consequently avoids this error.

I also fixed the CHANGELOG to have nicer formatting and added the fix from #311 to the notes for the 0.0.9 release.

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


