### PR TITLE
Trim down data before plotting.

### DIFF
--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -94,7 +94,7 @@ def layout():
                             value=2,
                             marks={
                                 i + 1: '{}'.format(i + 1)
-                                for i in range(9)
+                                for i in range(4)
                             },
                             step=0.05
                         ),
@@ -114,7 +114,7 @@ def layout():
                             value=3,
                             marks={
                                 i + 1: '{}'.format(i + 1)
-                                for i in range(9)
+                                for i in range(4)
                             },
                             step=0.05
                         )

--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -18,7 +18,13 @@ elif 'DASH_PATH_ROUTING' in os.environ:
 DATAPATH = os.path.join(".", "tests", "dashbio_demos", "sample_data", "manhattan_")
 
 # Load the data
-DATASET = pd.read_csv("{}data.csv".format(DATAPATH))
+DT = pd.read_csv("{}data.csv".format(DATAPATH))
+
+# Trim down the data
+datasets = [DT.loc[DT['CHR'] == i+1] for i in range(23)]
+datasets = [dataset.iloc[:100] for dataset in datasets]
+
+DATASET = pd.concat(datasets).reset_index(drop=True)
 
 # Feed the data to a function which creates a Manhattan Plot figure
 fig = dash_bio.ManhattanPlot(DATASET)
@@ -83,9 +89,9 @@ def layout():
                             id='mhp-slider-genome',
                             vertical=False,
                             updatemode='mouseup',
-                            max=9,
+                            max=4,
                             min=1,
-                            value=7,
+                            value=2,
                             marks={
                                 i + 1: '{}'.format(i + 1)
                                 for i in range(9)
@@ -103,9 +109,9 @@ def layout():
                             id='mhp-slider-indic',
                             vertical=False,
                             updatemode='mouseup',
-                            max=9,
+                            max=4,
                             min=1,
-                            value=6,
+                            value=3,
                             marks={
                                 i + 1: '{}'.format(i + 1)
                                 for i in range(9)

--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -1,4 +1,5 @@
 import os
+
 import pandas as pd
 import dash_html_components as html
 import dash_core_components as dcc
@@ -17,16 +18,19 @@ elif 'DASH_PATH_ROUTING' in os.environ:
 
 DATAPATH = os.path.join(".", "tests", "dashbio_demos", "sample_data", "manhattan_")
 
-# Load the data
-DT = pd.read_csv("{}data.csv".format(DATAPATH))
+# Load dataset into a DataFrame
+df = pd.read_csv('{}data.csv'.format(DATAPATH))
 
+n_chr = 23  # number of chromosome pairs in humans
+assert 'CHR' in df.columns
+assert df['CHR'].max() == n_chr
+
+# Split data by chromosome
+datasets = [df.loc[df['CHR'] == i + 1] for i in range(n_chr)]
 # Trim down the data
-if 'CHR' in DT:
-    datasets = [DT.loc[DT['CHR'] == i+1] for i in range(DT['CHR'].max())]
-    datasets = [dataset.iloc[:50] for dataset in datasets]
-    DATASET = pd.concat(datasets).reset_index(drop=True)
-else:
-    DATASET = None
+datasets = [dataset.iloc[:50] for dataset in datasets]
+# Rebind subsets together
+DATASET = pd.concat(datasets).reset_index(drop=True)
 
 # Feed the data to a function which creates a Manhattan Plot figure
 fig = dash_bio.ManhattanPlot(DATASET)

--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -21,7 +21,7 @@ DATAPATH = os.path.join(".", "tests", "dashbio_demos", "sample_data", "manhattan
 DT = pd.read_csv("{}data.csv".format(DATAPATH))
 
 # Trim down the data
-datasets = [DT.loc[DT['CHR'] == i+1] for i in range(23)]
+datasets = [DT.loc[DT['CHR'] == i+1] for i in range(DT['CHR'].max())]
 datasets = [dataset.iloc[:50] for dataset in datasets]
 
 DATASET = pd.concat(datasets).reset_index(drop=True)

--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -21,10 +21,12 @@ DATAPATH = os.path.join(".", "tests", "dashbio_demos", "sample_data", "manhattan
 DT = pd.read_csv("{}data.csv".format(DATAPATH))
 
 # Trim down the data
-datasets = [DT.loc[DT['CHR'] == i+1] for i in range(DT['CHR'].max())]
-datasets = [dataset.iloc[:50] for dataset in datasets]
-
-DATASET = pd.concat(datasets).reset_index(drop=True)
+if 'CHR' in DT:
+    datasets = [DT.loc[DT['CHR'] == i+1] for i in range(DT['CHR'].max())]
+    datasets = [dataset.iloc[:50] for dataset in datasets]
+    DATASET = pd.concat(datasets).reset_index(drop=True)
+else:
+    DATASET = None
 
 # Feed the data to a function which creates a Manhattan Plot figure
 fig = dash_bio.ManhattanPlot(DATASET)

--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -22,7 +22,7 @@ DT = pd.read_csv("{}data.csv".format(DATAPATH))
 
 # Trim down the data
 datasets = [DT.loc[DT['CHR'] == i+1] for i in range(23)]
-datasets = [dataset.iloc[:100] for dataset in datasets]
+datasets = [dataset.iloc[:50] for dataset in datasets]
 
 DATASET = pd.concat(datasets).reset_index(drop=True)
 

--- a/tests/dashbio_demos/app_manhattan_plot.py
+++ b/tests/dashbio_demos/app_manhattan_plot.py
@@ -25,12 +25,9 @@ n_chr = 23  # number of chromosome pairs in humans
 assert 'CHR' in df.columns
 assert df['CHR'].max() == n_chr
 
-# Split data by chromosome
-datasets = [df.loc[df['CHR'] == i + 1] for i in range(n_chr)]
 # Trim down the data
-datasets = [dataset.iloc[:50] for dataset in datasets]
-# Rebind subsets together
-DATASET = pd.concat(datasets).reset_index(drop=True)
+DATASET = df.groupby('CHR').apply(lambda u: u.head(50))
+DATASET = DATASET.droplevel('CHR').reset_index(drop=True)
 
 # Feed the data to a function which creates a Manhattan Plot figure
 fig = dash_bio.ManhattanPlot(DATASET)


### PR DESCRIPTION
Addresses part of #289 

## Description of changes 
Trim down the dataset to use only the first 100 rows of the data for each chromosome in order to speed up load/response times for the graph. 

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


