### PR TITLE
Specify pandas version in requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ gunicorn
 jsonschema
 matplotlib
 numpy
-pandas
+pandas>=0.24.2
 parmed
 plotly>=3.5.0
 requests


### PR DESCRIPTION
## Description of changes 
Deployment to DDS fails because the version of `pandas` is not specified. If there is already a version of `pandas` installed in the container, it will not update (because `pip` will recognize the package as already having been installed). We didn't run into this problem with the demo apps because the heroku containers are ephemeral and consequently will always have the latest version of `pandas`.

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


