### PR TITLE
Remove API token from CI status badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dash Bio
 
-[![CircleCI](https://circleci.com/gh/plotly/dash-bio/tree/master.svg?style=svg&circle-token=514e349727fb30e6b85bdaa8269aef3b3e1d320e)](https://circleci.com/gh/plotly/dash-bio/tree/master)
+[![CircleCI](https://circleci.com/gh/plotly/dash-bio/tree/master.svg?style=svg)](https://circleci.com/gh/plotly/dash-bio)
 
 🚧 *Work-in-Progress* 🏗️
 


### PR DESCRIPTION
This API token is unnecessary, now that the project is public.

## About 
This is a minor change.

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)


