### PR TITLE
Take snapshot of Python environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,19 +2,19 @@
 
 # Switch into a virtual environment
 # pip install -r requirements.txt
-biopython
+biopython==1.73
 colour==0.1.5
 cython>=0.19
-dash>=0.40.0
+dash==0.40.0
 dash-bio==0.0.9-rc10
 dash-daq==0.1.4
-gunicorn
-jsonschema
-matplotlib
-numpy
+gunicorn==19.9.0
+jsonschema==2.6.0
+matplotlib==3.0.2
+numpy==1.15.4
 pandas>=0.24.2
-parmed
+parmed==3.1.0
 plotly>=3.5.0
-requests
+requests==2.21.0
 scipy>=1.1.0
-scikit-learn
+scikit-learn==0.20.2


### PR DESCRIPTION
Closes #332 

## About 
With this change, we shouldn't run into any more surprises when deployment with DDS. That being said, I don't understand why the current version of Dash would be `>=0.40.0` (https://github.com/plotly/dash-bio/blame/master/requirements.txt didn't enlighten me): I 'reverted' `dash>=0.40.0` to `dash==0.40.0` because, if I remember correctly, we need to upgrade React to v16 before we can upgrade our Dash dependency.

## Description of changes 
I have used package versions from my local dev environment (output of `pip freeze`).

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)