### PR TITLE
Double timeout for Ideogram tests which fail often.

### DIFF
--- a/tests/test_ideogram.py
+++ b/tests/test_ideogram.py
@@ -234,7 +234,7 @@ def test_ploidy(dash_threaded):
     btn.click()
 
     # assert doubling of the 22 chromosomes + X and Y chromosomes
-    chromosomes = wait_for_elements_by_css_selector(driver, '.chromosome')
+    chromosomes = wait_for_elements_by_css_selector(driver, '.chromosome', timeout=20)
     assert len(chromosomes) == 46
 
 
@@ -314,7 +314,7 @@ def test_chromosomes_wrong_input(dash_threaded):
     btn.click()
 
     # assert the set of chromosomes contains 2 chromosomes
-    chromosomes = wait_for_elements_by_css_selector(driver, '.chromosome')
+    chromosomes = wait_for_elements_by_css_selector(driver, '.chromosome', timeout=20)
     assert len(chromosomes) == 2
 
 
@@ -489,7 +489,7 @@ def test_sex(dash_threaded):
     btn.click()
 
     # assert the absence of the chromosome Y
-    chromosomes = wait_for_elements_by_css_selector(driver, '.chromosome')
+    chromosomes = wait_for_elements_by_css_selector(driver, '.chromosome', timeout=20)
     num_chromosoms = len(chromosomes)
     assert num_chromosoms == 23
 


### PR DESCRIPTION
## About
The `selenium` utility https://github.com/plotly/pytest-dash/blob/d0291909b1230f3c39473b6f038ae7a6b48670c3/pytest_dash/wait_for.py#L44 often fails to find the elements identified in some of our tests (specifically in file `tests/test_ideogram.py`) within the default timeout. Values we test for are therefore not updated, leading to CI build failures (we then relaunch CI builds manually).

## Description of changes
This changeset won't change the world, but it could spare us a few CI fails (iirc, last time I toyed with this, I ended up not submitting the change because I wasn't able to observe these timeout-related fails locally). Also, note that this change will be subject to the upcoming refactoring of `pytest-dash` by @byronz.

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)
