### PR TITLE
React 16 upgrade

### DIFF
--- a/dash_bio/package-info.json
+++ b/dash_bio/package-info.json
@@ -1,1 +1,1 @@
-{"name": "dash_bio", "version": "0.1.2-rc1", "author": "The Plotly Team <dashbio@plot.ly>"}
+{"name": "dash_bio", "version": "0.1.3-rc1", "author": "The Plotly Team <dashbio@plot.ly>"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.1.2-rc1",
+  "version": "0.1.3-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1133,9 +1133,9 @@
       "integrity": "sha512-dyQxe6ukILV6qaEvxoKCIwhblgRjYp1ZGlClo4xvfbmxzFO5LYu7Tnrg2AZrRgN7VsSragsGcNjzUe9kCdKHYQ=="
     },
     "@mapbox/tiny-sdf": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.0.tgz",
-      "integrity": "sha512-dnhyk8X2BkDRWImgHILYAGgo+kuciNYX30CUKj/Qd5eNjh54OWM/mdOS/PWsPeN+3abtN+QDGYM4G220ynVJKA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
+      "integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg=="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
@@ -1154,6 +1154,16 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
+    },
+    "@plotly/d3-sankey": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
+      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
+      "requires": {
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-shape": "^1.2.0"
+      }
     },
     "@types/accepts": {
       "version": "1.3.5",
@@ -1561,6 +1571,11 @@
         "acorn": "^5.0.0"
       }
     },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
+    },
     "add-line-numbers": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
@@ -1959,7 +1974,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-polyfill": {
@@ -2104,9 +2119,9 @@
       "dev": true
     },
     "binary-search-bounds": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
-      "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
+      "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
     },
     "bio.io": {
       "version": "1.0.6",
@@ -2198,9 +2213,9 @@
       }
     },
     "box-intersect": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
-      "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.2.tgz",
+      "integrity": "sha512-yJeMwlmFPG1gIa7Rs/cGXeI6iOj6Qz5MG5PE61xLKpElUGzmJ4abm+qsLpzxKJFpsSDq742BQEocr8dI2t8Nxw==",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "typedarray-pool": "^1.1.0"
@@ -2416,37 +2431,93 @@
       }
     },
     "buble": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.6.tgz",
-      "integrity": "sha512-9kViM6nJA1Q548Jrd06x0geh+BG2ru2+RMDkIHHgJY/8AcyCs34lTHwra9BX7YdPrZXd5aarkpr/SY8bmPgPdg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.7.tgz",
+      "integrity": "sha512-YLgWxX/l+NnfotydBlxqCMPR4FREE4ubuHphALz0FxQ7u2hp3BzxTKQ4nKpapOaRJfEm1gukC68KnT2OymRK0g==",
       "requires": {
-        "chalk": "^2.4.1",
-        "magic-string": "^0.25.1",
+        "acorn": "^6.1.1",
+        "acorn-dynamic-import": "^4.0.0",
+        "acorn-jsx": "^5.0.1",
+        "chalk": "^2.4.2",
+        "magic-string": "^0.25.2",
         "minimist": "^1.2.0",
         "os-homedir": "^1.0.1",
-        "regexpu-core": "^4.2.0",
-        "vlq": "^1.0.0"
+        "regexpu-core": "^4.5.4"
       },
       "dependencies": {
-        "magic-string": {
-          "version": "0.25.1",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
-          "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
+        },
+        "acorn-dynamic-import": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+          "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "sourcemap-codec": "^1.4.1"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
-        "vlq": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
-          "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g=="
+        "magic-string": {
+          "version": "0.25.2",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+          "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        },
+        "regenerate-unicode-properties": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+          "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regexpu-core": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+          "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.0.2",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.1.0"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+          "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
+        },
+        "regjsparser": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+          "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+          "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
         }
       }
     },
     "bubleify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.2.0.tgz",
-      "integrity": "sha512-SJnUsR+f8WeDw0K2l1S+VuYI33Cu5Gfghe5jTow/fpJueNtnwyoECyfCGsDuFoQt4QGhjpV3LYPpN0hxy90LgA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.2.1.tgz",
+      "integrity": "sha512-vp3NHmaQVoKaKWvi15FTMinPNjfp+47+/kFJ9ifezdMF/CBLArCxDVUh+FQE3qRxCRj1qyjJqilTBHHqlM8MaQ==",
       "requires": {
         "buble": "^0.19.3"
       }
@@ -2635,13 +2706,6 @@
         "binary-search-bounds": "^2.0.3",
         "robust-in-sphere": "^1.1.3",
         "robust-orientation": "^1.1.3"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        }
       }
     },
     "cell-orientation": {
@@ -2662,6 +2726,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -3021,11 +3086,11 @@
       }
     },
     "color-alpha": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.3.tgz",
-      "integrity": "sha512-ap5UCPpnpsSQu09ccl/5cNQDJlSFvkuXHMBY1+1vu6iKj6H9zw7Sz852snsETFsrYlPUnvTByCFAnYVynKJb9A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
+      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
       "requires": {
-        "color-parse": "^1.2.0"
+        "color-parse": "^1.3.8"
       }
     },
     "color-convert": {
@@ -3067,9 +3132,9 @@
       }
     },
     "color-parse": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.7.tgz",
-      "integrity": "sha512-8G6rPfyTZhWYKU7D2hwywTjA4YlqX/Z7ClqTEzh5ENc5QkLOff0u8EuyNZR6xScEBhWpAyiDrrVGNUE/Btg2LA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
+      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
       "requires": {
         "color-name": "^1.0.0",
         "defined": "^1.0.0",
@@ -3077,12 +3142,12 @@
       }
     },
     "color-rgba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.0.tgz",
-      "integrity": "sha512-yAmMouVOLRAtYJwP52qymiscIMpw2g7VO82pkW+a88BpW1AZ+O6JDxAAojLljGO0pQkkvZLLN9oQNTEgT+RFiw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
+      "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
       "requires": {
         "clamp": "^1.0.1",
-        "color-parse": "^1.3.7",
+        "color-parse": "^1.3.8",
         "color-space": "^1.14.6"
       }
     },
@@ -3093,6 +3158,14 @@
       "requires": {
         "hsluv": "^0.0.3",
         "mumath": "^3.3.4"
+      }
+    },
+    "colormap": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.1.tgz",
+      "integrity": "sha512-TEzNlo/qYp6pBoR2SK9JiV+DG1cmUcVO/+DEJqVPSHIKNlWh5L5L4FYog7b/h0bAnhKhpOAvx/c1dFp2QE9sFw==",
+      "requires": {
+        "lerp": "^1.0.3"
       }
     },
     "combined-stream": {
@@ -3906,9 +3979,9 @@
       }
     },
     "d3-force": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
-      "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
       "requires": {
         "d3-collection": "1",
         "d3-dispatch": "1",
@@ -3953,9 +4026,9 @@
       "integrity": "sha1-FoiOkCZGCTPysXllKtN4Ik04LGI="
     },
     "d3-quadtree": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
-      "integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.6.tgz",
+      "integrity": "sha512-NUgeo9G+ENQCQ1LsRr2qJg3MQ4DJvxcDNCiohdJGHt5gRhBW6orIB5m5FJ9kK3HNL8g9F4ERVoBzcEwQBfXWVA=="
     },
     "d3-queue": {
       "version": "3.0.7",
@@ -4349,9 +4422,9 @@
       }
     },
     "earcut": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.3.tgz",
-      "integrity": "sha512-AxdCdWUk1zzK/NuZ7e1ljj6IGC+VAdC3Qb7QQDsXpfNrc5IM8tL9nNXUmEGE6jRHTfZ10zhzRhtDmWVsR5pd3A=="
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.5.tgz",
+      "integrity": "sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -4492,13 +4565,13 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.46",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
@@ -4551,6 +4624,18 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
     },
     "eslint": {
       "version": "5.12.1",
@@ -4933,11 +5018,6 @@
         }
       }
     },
-    "expect.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.2.0.tgz",
-      "integrity": "sha1-EChTPSwcNj90pnlv9X7AUg3tK+E="
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5139,6 +5219,13 @@
       "requires": {
         "binary-search-bounds": "^1.0.0",
         "cubic-hermite": "^1.0.0"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "find-cache-dir": {
@@ -6132,66 +6219,6 @@
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
         "vectorize-text": "^3.2.1"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-buffer": {
@@ -6214,72 +6241,28 @@
         "glsl-inverse": "^1.0.0",
         "glsl-out-of-range": "^1.0.4",
         "glslify": "^7.0.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-constants/-/gl-constants-1.0.0.tgz",
       "integrity": "sha1-WXpQTjZHUP9QJTqjX43qevSl0jM="
+    },
+    "gl-contour2d": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/gl-contour2d/-/gl-contour2d-1.1.5.tgz",
+      "integrity": "sha512-XNMXVoWgD0gbQw2k3qxiFTNJfrwTqLyOS1ed9eiDksMj2pnGatRA9fK8KN7yDOqYEZdY7ZXtAmAasqMgsaosDw==",
+      "requires": {
+        "binary-search-bounds": "^2.0.0",
+        "cdt2d": "^1.0.0",
+        "clean-pslg": "^1.1.0",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.0.5",
+        "glslify": "^7.0.0",
+        "iota-array": "^1.0.0",
+        "ndarray": "^1.0.18",
+        "surface-nets": "^1.0.2"
+      }
     },
     "gl-error3d": {
       "version": "1.0.15",
@@ -6291,66 +6274,6 @@
         "gl-vao": "^1.3.0",
         "glsl-out-of-range": "^1.0.4",
         "glslify": "^7.0.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-fbo": {
@@ -6372,6 +6295,19 @@
         "sprintf-js": "^1.0.3"
       }
     },
+    "gl-heatmap2d": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.0.5.tgz",
+      "integrity": "sha512-nki9GIh0g4OXKNIrlnAT/gy/uXxkwrFKgI+XwRcUO6nLBM1WbI2hl8EPykNFXCqsyd08HJQbXKiqaHPW7cNpJg==",
+      "requires": {
+        "binary-search-bounds": "^2.0.3",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.0.5",
+        "glslify": "^7.0.0",
+        "iota-array": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
     "gl-line3d": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.1.11.tgz",
@@ -6386,71 +6322,6 @@
         "glsl-read-float": "^1.0.0",
         "glslify": "^7.0.0",
         "ndarray": "^1.0.16"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-mat2": {
@@ -6498,74 +6369,6 @@
         "polytope-closest-point": "^1.0.0",
         "simplicial-complex-contour": "^1.0.0",
         "typedarray-pool": "^1.1.0"
-      },
-      "dependencies": {
-        "colormap": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.1.tgz",
-          "integrity": "sha512-TEzNlo/qYp6pBoR2SK9JiV+DG1cmUcVO/+DEJqVPSHIKNlWh5L5L4FYog7b/h0bAnhKhpOAvx/c1dFp2QE9sFw==",
-          "requires": {
-            "lerp": "^1.0.3"
-          }
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-plot2d": {
@@ -6580,83 +6383,6 @@
         "glsl-inverse": "^1.0.0",
         "glslify": "^7.0.0",
         "text-cache": "^4.2.1"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
-        "gl-select-static": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.4.tgz",
-          "integrity": "sha512-4Kqx5VjeT8nmV+j6fry3UBFNL2B7ktQU4o508QGVPKWCILlV44rTDq3mnBFThup8rMIH9kJQx6xWsg9jTmfeMw==",
-          "requires": {
-            "bit-twiddle": "^1.0.2",
-            "cwise": "^1.0.3",
-            "gl-fbo": "^2.0.3",
-            "ndarray": "^1.0.15",
-            "typedarray-pool": "^1.1.0"
-          }
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-plot3d": {
@@ -6680,89 +6406,17 @@
         "mouse-wheel": "^1.2.0",
         "ndarray": "^1.0.18",
         "right-now": "^1.0.0"
-      },
-      "dependencies": {
-        "gl-select-static": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.4.tgz",
-          "integrity": "sha512-4Kqx5VjeT8nmV+j6fry3UBFNL2B7ktQU4o508QGVPKWCILlV44rTDq3mnBFThup8rMIH9kJQx6xWsg9jTmfeMw==",
-          "requires": {
-            "bit-twiddle": "^1.0.2",
-            "cwise": "^1.0.3",
-            "gl-fbo": "^2.0.3",
-            "ndarray": "^1.0.15",
-            "typedarray-pool": "^1.1.0"
-          }
-        },
-        "gl-spikes3d": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.8.tgz",
-          "integrity": "sha512-C9Ij2/vpyjFGQBO2dDG4WsS8ZLWbFdL+nnqBeWqYe8SER96R+ZBMH/wddwZsxPV2iKlK9x2a8z3fSohw6V8Ayg==",
-          "requires": {
-            "gl-buffer": "^2.1.2",
-            "gl-shader": "^4.2.1",
-            "gl-vao": "^1.3.0",
-            "glslify": "^7.0.0"
-          }
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
+      }
+    },
+    "gl-pointcloud2d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.2.tgz",
+      "integrity": "sha512-KDfuJLg1dFWNPo6eJYgwUpNdVcIdK5y29ZiYpzzP0qh3eg0bSLMq8ZkaqvPmSJsFksUryT73IRunsuxJtTJkvA==",
+      "requires": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-quat": {
@@ -6789,66 +6443,28 @@
         "is-string-blank": "^1.0.1",
         "typedarray-pool": "^1.0.2",
         "vectorize-text": "^3.2.1"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
+      }
+    },
+    "gl-select-box": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.3.tgz",
+      "integrity": "sha512-sQb18g1aZ6PJAsvsC8nNYhuhc2TYXNbzVbI0bP9AH9770NjrDnd7TC8HHcfu8nJXGPG69HjqR6EzS+QSqiXPSA==",
+      "requires": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.0.5",
+        "glslify": "^7.0.0"
+      }
+    },
+    "gl-select-static": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.4.tgz",
+      "integrity": "sha512-4Kqx5VjeT8nmV+j6fry3UBFNL2B7ktQU4o508QGVPKWCILlV44rTDq3mnBFThup8rMIH9kJQx6xWsg9jTmfeMw==",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "cwise": "^1.0.3",
+        "gl-fbo": "^2.0.3",
+        "ndarray": "^1.0.15",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-shader": {
@@ -6858,6 +6474,22 @@
       "requires": {
         "gl-format-compiler-error": "^1.0.2",
         "weakmap-shim": "^1.1.0"
+      }
+    },
+    "gl-spikes2d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gl-spikes2d/-/gl-spikes2d-1.0.2.tgz",
+      "integrity": "sha512-QVeOZsi9nQuJJl7NB3132CCv5KA10BWxAY2QgJNsKqbLsG53B/TrGJpjIAohnJftdZ4fT6b3ZojWgeaXk8bOOA=="
+    },
+    "gl-spikes3d": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.8.tgz",
+      "integrity": "sha512-C9Ij2/vpyjFGQBO2dDG4WsS8ZLWbFdL+nnqBeWqYe8SER96R+ZBMH/wddwZsxPV2iKlK9x2a8z3fSohw6V8Ayg==",
+      "requires": {
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glslify": "^7.0.0"
       }
     },
     "gl-state": {
@@ -6877,66 +6509,6 @@
         "glsl-inverse": "^1.0.0",
         "glsl-out-of-range": "^1.0.4",
         "glslify": "^7.0.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-surface3d": {
@@ -6963,79 +6535,6 @@
         "ndarray-scratch": "^1.1.1",
         "surface-nets": "^1.0.2",
         "typedarray-pool": "^1.0.0"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
-        "colormap": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.1.tgz",
-          "integrity": "sha512-TEzNlo/qYp6pBoR2SK9JiV+DG1cmUcVO/+DEJqVPSHIKNlWh5L5L4FYog7b/h0bAnhKhpOAvx/c1dFp2QE9sFw==",
-          "requires": {
-            "lerp": "^1.0.3"
-          }
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-text": {
@@ -7073,9 +6572,9 @@
       }
     },
     "gl-util": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.0.tgz",
-      "integrity": "sha512-r/krwAgz7KWsp4A5XhUhSozmbjLaicoaiX1hJhgpUv/V5B7TCiEaRCBN20z/A4SR+u52HUjcAOW21lDg4CPZrA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.2.tgz",
+      "integrity": "sha512-8czWhGTGp/H4S35X1UxGbFlJ1hjtTFhm2mc85GcymEi1CDf633WJgtkCddEiSjIa4BnNxBrqOIhj6jlF6naPqw==",
       "requires": {
         "is-browser": "^2.0.1",
         "is-firefox": "^1.0.3",
@@ -7105,6 +6604,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7287,6 +6787,66 @@
         "through2": "^0.6.3"
       }
     },
+    "glslify": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
+      "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
+      "requires": {
+        "bl": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "duplexify": "^3.4.5",
+        "falafel": "^2.1.0",
+        "from2": "^2.3.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glslify-bundle": "^5.0.0",
+        "glslify-deps": "^1.2.5",
+        "minimist": "^1.2.0",
+        "resolve": "^1.1.5",
+        "stack-trace": "0.0.9",
+        "static-eval": "^2.0.0",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
     "glslify-bundle": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
@@ -7343,9 +6903,9 @@
       }
     },
     "grid-index": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.0.0.tgz",
-      "integrity": "sha1-rSxdVM5bNUN/r/HXCprrPR0mERA="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "grunt-cli": {
       "version": "0.1.13",
@@ -7792,6 +7352,13 @@
       "integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
       "requires": {
         "binary-search-bounds": "^1.0.0"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "invariant": {
@@ -8691,6 +8258,13 @@
         "gl-mat4": "^1.1.2",
         "gl-vec3": "^1.0.3",
         "mat4-interpolate": "^1.0.3"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "md5.js": {
@@ -9004,6 +8578,31 @@
         "keymirror": "^0.1.1",
         "react": "^15.5.0",
         "react-dom": "^15.3.2"
+      },
+      "dependencies": {
+        "react": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+          "requires": {
+            "create-react-class": "^15.6.0",
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.0",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "react-dom": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+          "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+          "requires": {
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.0",
+            "prop-types": "^15.5.10"
+          }
+        }
       }
     },
     "monotone-convex-hull-2d": {
@@ -9774,9 +9373,9 @@
       }
     },
     "parenthesis": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.5.tgz",
-      "integrity": "sha512-9KbfUp3+gD0MIl4AGfLBwVNvcPf1fokUJtYxql511chVNnS8DrYFazqBfZDqD4GV76XUhQbbxmZJPPOsV4GIbw=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.6.tgz",
+      "integrity": "sha512-2fobSoJQTFoIKJ2kXw8QupNtKJ93lNwRgwBxf8YxMNWnWwvMVzqs/baseqWhHP1bRQGf0cv75UtO71nUO5dFuA=="
     },
     "parse-asn1": {
       "version": "5.1.1",
@@ -9906,12 +9505,12 @@
       }
     },
     "pbf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
-      "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.0.tgz",
+      "integrity": "sha512-98Eh7rsJNJF/Im6XYMLaOW3cLnNyedlOd6hu3iWMD5I7FZGgpw8yN3vQBrmLbLodu7G784Irb9Qsv2yFrxSAGw==",
       "requires": {
-        "ieee754": "^1.1.6",
-        "resolve-protobuf-schema": "^2.0.0"
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       }
     },
     "pbkdf2": {
@@ -10070,13 +9669,12 @@
       }
     },
     "plotly.js": {
-      "version": "1.47.4",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.47.4.tgz",
-      "integrity": "sha512-dGawdp62+Nh5/ndHF5WGmq0+DfrnSl/dBcwotsj4bx4FcfTX51zaZsYI9itIp+ShjCkB3j681RMnkh4Hok/Y6g==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.48.1.tgz",
+      "integrity": "sha512-1dar+duEcH0+kVbiwf2xw0oCkm5UNPg5h7Qs9qa5Ak9wRnRq41yGYpjz8myzuLsQ2tEISc8FXiQdCG5wIt2UFQ==",
       "requires": {
         "@plotly/d3-sankey": "0.7.2",
         "alpha-shape": "^1.0.0",
-        "array-range": "^1.0.1",
         "canvas-fit": "^1.5.0",
         "color-normalize": "^1.3.0",
         "convex-hull": "^1.0.3",
@@ -10126,7 +9724,7 @@
         "regl-splom": "^1.0.6",
         "right-now": "^1.0.0",
         "robust-orientation": "^1.1.3",
-        "sane-topojson": "^2.0.0",
+        "sane-topojson": "^3.0.1",
         "strongly-connected-components": "^1.0.1",
         "superscript-text": "^1.0.0",
         "svg-path-sdf": "^1.1.3",
@@ -10136,177 +9734,10 @@
         "world-calendars": "^1.0.3"
       },
       "dependencies": {
-        "@plotly/d3-sankey": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
-          "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
-          "requires": {
-            "d3-array": "1",
-            "d3-collection": "1",
-            "d3-shape": "^1.2.0"
-          }
-        },
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
         "d3-hierarchy": {
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
           "integrity": "sha512-L+GHMSZNwTpiq4rt9GEsNcpLa4M96lXMR8M/nMG9p5hBE0jy6C+3hWtyZMenPQdwla249iJy7Nx0uKt3n+u9+w=="
-        },
-        "gl-contour2d": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/gl-contour2d/-/gl-contour2d-1.1.5.tgz",
-          "integrity": "sha512-XNMXVoWgD0gbQw2k3qxiFTNJfrwTqLyOS1ed9eiDksMj2pnGatRA9fK8KN7yDOqYEZdY7ZXtAmAasqMgsaosDw==",
-          "requires": {
-            "binary-search-bounds": "^2.0.0",
-            "cdt2d": "^1.0.0",
-            "clean-pslg": "^1.1.0",
-            "gl-buffer": "^2.1.2",
-            "gl-shader": "^4.0.5",
-            "glslify": "^7.0.0",
-            "iota-array": "^1.0.0",
-            "ndarray": "^1.0.18",
-            "surface-nets": "^1.0.2"
-          }
-        },
-        "gl-heatmap2d": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.0.5.tgz",
-          "integrity": "sha512-nki9GIh0g4OXKNIrlnAT/gy/uXxkwrFKgI+XwRcUO6nLBM1WbI2hl8EPykNFXCqsyd08HJQbXKiqaHPW7cNpJg==",
-          "requires": {
-            "binary-search-bounds": "^2.0.3",
-            "gl-buffer": "^2.1.2",
-            "gl-shader": "^4.0.5",
-            "glslify": "^7.0.0",
-            "iota-array": "^1.0.0",
-            "typedarray-pool": "^1.1.0"
-          }
-        },
-        "gl-pointcloud2d": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.2.tgz",
-          "integrity": "sha512-KDfuJLg1dFWNPo6eJYgwUpNdVcIdK5y29ZiYpzzP0qh3eg0bSLMq8ZkaqvPmSJsFksUryT73IRunsuxJtTJkvA==",
-          "requires": {
-            "gl-buffer": "^2.1.2",
-            "gl-shader": "^4.2.1",
-            "glslify": "^7.0.0",
-            "typedarray-pool": "^1.1.0"
-          }
-        },
-        "gl-select-box": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.3.tgz",
-          "integrity": "sha512-sQb18g1aZ6PJAsvsC8nNYhuhc2TYXNbzVbI0bP9AH9770NjrDnd7TC8HHcfu8nJXGPG69HjqR6EzS+QSqiXPSA==",
-          "requires": {
-            "gl-buffer": "^2.1.2",
-            "gl-shader": "^4.0.5",
-            "glslify": "^7.0.0"
-          }
-        },
-        "gl-spikes2d": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/gl-spikes2d/-/gl-spikes2d-1.0.2.tgz",
-          "integrity": "sha512-QVeOZsi9nQuJJl7NB3132CCv5KA10BWxAY2QgJNsKqbLsG53B/TrGJpjIAohnJftdZ4fT6b3ZojWgeaXk8bOOA=="
-        },
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "regl": {
-          "version": "1.3.11",
-          "resolved": "https://registry.npmjs.org/regl/-/regl-1.3.11.tgz",
-          "integrity": "sha512-tmt6CRhRqbcsYDWNwv+iG7GGOXdgoOBC7lKzoPMgnzpt3WKBQ3c8i7AxgbvTRZzty29hrW92fAJeZkPFQehfWA=="
-        },
-        "regl-error2d": {
-          "version": "2.0.7",
-          "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.7.tgz",
-          "integrity": "sha512-YCXlu3BIDpR1hsU8HqMn+SiRldevdP2gIFNpaOdBSV2PEJsMmDHo532elzU2K3sB7heDqZzXuY66CfYRL89oDg==",
-          "requires": {
-            "array-bounds": "^1.0.1",
-            "bubleify": "^1.0.0",
-            "color-normalize": "^1.0.3",
-            "flatten-vertex-data": "^1.0.0",
-            "object-assign": "^4.1.1",
-            "pick-by-alias": "^1.1.1",
-            "to-float32": "^1.0.0",
-            "update-diff": "^1.0.2"
-          }
-        },
-        "regl-line2d": {
-          "version": "3.0.13",
-          "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.13.tgz",
-          "integrity": "sha512-bTsuvTw4No25kUKGiXwOm0sLJT9kZ7vAkZOZYyXLxKCMRYIz1TS0j7DfqtC5ammzni8AdSahuTT0x52RU4Izuw==",
-          "requires": {
-            "array-bounds": "^1.0.0",
-            "array-normalize": "^1.1.3",
-            "bubleify": "^1.0.0",
-            "color-normalize": "^1.0.0",
-            "earcut": "^2.1.1",
-            "es6-weak-map": "^2.0.2",
-            "flatten-vertex-data": "^1.0.0",
-            "glslify": "^7.0.0",
-            "object-assign": "^4.1.1",
-            "parse-rect": "^1.2.0",
-            "pick-by-alias": "^1.1.0",
-            "to-float32": "^1.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
         }
       }
     },
@@ -10317,9 +9748,9 @@
       "dev": true
     },
     "point-cluster": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.4.tgz",
-      "integrity": "sha512-jVjzC1vYoZlvcLWi170i41he5LhJTncOgFPaZx1uoqNn+8q+24xjLS9yG68XfN6/U1F52kliD6a3oXjJduerTQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.5.tgz",
+      "integrity": "sha512-KpVtB1mXDlo6yzv80MA6oUq+1519CMeeUd4PPluM4ZlAQgHi/qeBrLY2G53RLy41kas7XvKol0FM98MSrjNH7Q==",
       "requires": {
         "array-bounds": "^1.0.1",
         "array-normalize": "^1.1.3",
@@ -10331,13 +9762,6 @@
         "is-obj": "^1.0.1",
         "math-log2": "^1.0.1",
         "parse-rect": "^1.2.0"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        }
       }
     },
     "point-in-big-polygon": {
@@ -10349,6 +9773,13 @@
         "interval-tree-1d": "^1.0.1",
         "robust-orientation": "^1.1.3",
         "slab-decomposition": "^1.0.1"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "polybooljs": {
@@ -10612,13 +10043,14 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pxls": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.1.tgz",
-      "integrity": "sha512-942Z8pHA2TLje4NM34Y0Zb6SqvkXq8s+IOM50J1wsYvHdPZfnUNu6U2Qld95dy50HtC9aKi8ZpHcc/iQjsQmeQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
+      "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
       "requires": {
         "arr-flatten": "^1.1.0",
         "compute-dims": "^1.1.0",
         "flip-pixels": "^1.0.2",
+        "is-browser": "^2.1.0",
         "is-buffer": "^2.0.3",
         "to-uint8": "^1.4.1"
       },
@@ -10744,15 +10176,14 @@
       }
     },
     "react": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
       "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
       }
     },
     "react-alignment-viewer": {
@@ -10827,13 +10258,14 @@
       }
     },
     "react-dom": {
-      "version": "15.4.2",
-      "resolved": "http://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz",
-      "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8=",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
       "requires": {
-        "fbjs": "^0.8.1",
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
       }
     },
     "react-input-autosize": {
@@ -11077,6 +10509,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+      "dev": true,
       "requires": {
         "regenerate": "^1.4.0"
       }
@@ -11138,6 +10571,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
       "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+      "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
         "regenerate-unicode-properties": "^7.0.0",
@@ -11150,20 +10584,56 @@
     "regjsgen": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
+      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+      "dev": true
     },
     "regjsparser": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+      "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
       }
     },
     "regl": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-1.3.9.tgz",
-      "integrity": "sha512-CungQSUBsZNYZJWJlb2sPe4iwBjmxrgl1Yxt91HN3VuuEL7lJ5k03O3T1xEXVOCMN1q8wncddwJsxozuyzzmrA=="
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.3.11.tgz",
+      "integrity": "sha512-tmt6CRhRqbcsYDWNwv+iG7GGOXdgoOBC7lKzoPMgnzpt3WKBQ3c8i7AxgbvTRZzty29hrW92fAJeZkPFQehfWA=="
+    },
+    "regl-error2d": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.7.tgz",
+      "integrity": "sha512-YCXlu3BIDpR1hsU8HqMn+SiRldevdP2gIFNpaOdBSV2PEJsMmDHo532elzU2K3sB7heDqZzXuY66CfYRL89oDg==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "bubleify": "^1.0.0",
+        "color-normalize": "^1.0.3",
+        "flatten-vertex-data": "^1.0.0",
+        "object-assign": "^4.1.1",
+        "pick-by-alias": "^1.1.1",
+        "to-float32": "^1.0.0",
+        "update-diff": "^1.0.2"
+      }
+    },
+    "regl-line2d": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.13.tgz",
+      "integrity": "sha512-bTsuvTw4No25kUKGiXwOm0sLJT9kZ7vAkZOZYyXLxKCMRYIz1TS0j7DfqtC5ammzni8AdSahuTT0x52RU4Izuw==",
+      "requires": {
+        "array-bounds": "^1.0.0",
+        "array-normalize": "^1.1.3",
+        "bubleify": "^1.0.0",
+        "color-normalize": "^1.0.0",
+        "earcut": "^2.1.1",
+        "es6-weak-map": "^2.0.2",
+        "flatten-vertex-data": "^1.0.0",
+        "glslify": "^7.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.1.0",
+        "to-float32": "^1.0.0"
+      }
     },
     "regl-scatter2d": {
       "version": "3.1.4",
@@ -11186,77 +10656,17 @@
         "point-cluster": "^3.1.4",
         "to-float32": "^1.0.1",
         "update-diff": "^1.1.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-          "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
-          "requires": {
-            "bl": "^1.0.0",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.0",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.0",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "regl-splom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.6.tgz",
-      "integrity": "sha512-2FEoHUBSQSHELf2hfw5Rya2DMrq/9RWbjKMlkKeMIrKG0+OjPHgZyxuSh/w7N91WXTTAh6GUehf9RueHSyGeWg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.7.tgz",
+      "integrity": "sha512-17ltp68/pCMFOU2gSIIFRTRMmsCRpDFzPUF9jkZhT8IDimI83jkU/2nP4vAHTIfd+HZ/Ip+eFrNx2aKV9FMDwQ==",
       "requires": {
         "array-bounds": "^1.0.1",
         "array-range": "^1.0.1",
         "bubleify": "^1.2.0",
-        "color-alpha": "^1.0.3",
+        "color-alpha": "^1.0.4",
         "defined": "^1.0.0",
         "flatten-vertex-data": "^1.0.2",
         "left-pad": "^1.3.0",
@@ -11619,9 +11029,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane-topojson": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sane-topojson/-/sane-topojson-2.0.0.tgz",
-      "integrity": "sha1-QOJXNqKMTM6qojP0W7hjc6J4W4Q="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sane-topojson/-/sane-topojson-3.0.1.tgz",
+      "integrity": "sha512-pntXgkpEHB3tTAO/rJM0aKLauq7uetB5T15NT1DMpDnbK853M9d8IiFD+WmVUDnyvZtfg3hQ5BC98fec8DlwaQ=="
     },
     "sax": {
       "version": "1.1.6",
@@ -11751,16 +11161,13 @@
       "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
     },
     "sharkdown": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.0.tgz",
-      "integrity": "sha1-YdT+Up510CRCEnzJI0NiJlCZIU8=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
+      "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
       "requires": {
         "cardinal": "~0.4.2",
-        "expect.js": "~0.2.0",
         "minimist": "0.0.5",
-        "split": "~0.2.10",
-        "stream-spigot": "~2.1.2",
-        "through": "~2.3.4"
+        "split": "~0.2.10"
       },
       "dependencies": {
         "minimist": {
@@ -11876,6 +11283,13 @@
         "binary-search-bounds": "^1.0.0",
         "functional-red-black-tree": "^1.0.0",
         "robust-orientation": "^1.1.3"
+      },
+      "dependencies": {
+        "binary-search-bounds": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+        }
       }
     },
     "slice-ansi": {
@@ -12126,9 +11540,9 @@
       }
     },
     "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -12161,36 +11575,11 @@
       "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
     },
     "static-eval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
-      "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
       "requires": {
         "escodegen": "^1.8.1"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-          "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
-          "requires": {
-            "esprima": "^3.1.3",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
-        }
       }
     },
     "static-extend": {
@@ -12434,27 +11823,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
-    "stream-spigot": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/stream-spigot/-/stream-spigot-2.1.2.tgz",
-      "integrity": "sha1-feFF6Bn43Q20UJDRPc9zqO08wDU=",
-      "requires": {
-        "readable-stream": "~1.1.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
-      }
-    },
     "string-split-by": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
@@ -12623,9 +11991,9 @@
       }
     },
     "svg-arc-to-cubic-bezier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.1.2.tgz",
-      "integrity": "sha512-scEWWUoCDhBtgamRnW8C4b0Va73GdpxwWs01SH/wNsl+al7FHEHsval/ZnutHfzvrNTcn/A3YIsQ1oNULSFS7g=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.1.3.tgz",
+      "integrity": "sha512-OyxEvzadllRxlvDiFBihKyl5He2jRvmRx/EyS5fzdz7OF+GF+6IDG9PxJLkyGViREmQMcRaNV92ZusXXoWMFaw=="
     },
     "svg-path-bounds": {
       "version": "1.0.1",
@@ -12679,23 +12047,46 @@
       "dev": true
     },
     "tape": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
-      "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.10.2.tgz",
+      "integrity": "sha512-mgl23h7W2yuk3N85FOYrin2OvThTYWdwbk6XQ1pr2PMJieyW2FM/4Bu/+kD/wecb3aZ0Enm+Syinyq467OPq2w==",
       "requires": {
         "deep-equal": "~1.0.1",
         "defined": "~1.0.0",
         "for-each": "~0.3.3",
         "function-bind": "~1.1.1",
-        "glob": "~7.1.2",
+        "glob": "~7.1.4",
         "has": "~1.0.3",
         "inherits": "~2.0.3",
         "minimist": "~1.2.0",
         "object-inspect": "~1.6.0",
-        "resolve": "~1.7.1",
+        "resolve": "~1.10.1",
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.1.2",
         "through": "~2.3.8"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "terser": {
@@ -12929,9 +12320,9 @@
       }
     },
     "to-array-buffer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.1.1.tgz",
-      "integrity": "sha512-tkmIT5W7XuQ1aEoSbeyRWAXMAdhSEnJCIdI+xOvlaF4/qktSYtQprVly9bcI+UqdAkQ/q/4UBbRgXO6IUcviJw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.2.0.tgz",
+      "integrity": "sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==",
       "requires": {
         "flatten-vertex-data": "^1.0.2",
         "is-blob": "^2.0.1",
@@ -13219,7 +12610,8 @@
     "unicode-match-property-value-ecmascript": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+      "dev": true
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.1.2-rc1",
+  "version": "0.1.3-rc1",
   "description": "Dash components for bioinformatics",
   "repository": {
     "type": "git",
@@ -28,11 +28,11 @@
     "circos": "^2.1.0",
     "ideogram": "git+https://github.com/eweitz/ideogram.git#7d9b2ab91b91ef35db93bdeb529d4760de63292f",
     "molecule-3d-for-react": "git://github.com/plotly/molecule-3d-for-react.git",
-    "plotly.js": "^1.47.4",
+    "plotly.js": "^1.48.1",
     "ramda": "^0.26.0",
-    "react": "15.6.2",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-alignment-viewer": "^0.5.5",
-    "react-dom": "15.4.2",
     "react-oncoprint": "^1.2.3",
     "react-plotly.js": "^2.2.0",
     "react-sequence-viewer": "git://github.com/plotly/react-sequence-viewer.git",
@@ -57,10 +57,6 @@
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.1",
     "webpack-serve": "^3.0.0"
-  },
-  "peerDependencies": {
-    "react": ">=0.14",
-    "react-dom": ">=0.14"
   },
   "files": [
     "dash_bio/bundle.js"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Switch into a virtual environment
 # pip install -r requirements.txt
 cython>=0.19
-dash==0.40.0
-dash-bio==0.1.2-rc1
+dash==0.43.0
+dash-bio==0.1.3-rc1
 dash-bio-utils==0.0.2
 dash-daq==0.1.4
 gunicorn==19.9.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'dash==0.40.0',
+        'dash==0.43.0',
         'pandas',
         'plotly',
         'scipy',


### PR DESCRIPTION
## About
This PR includes changes that will allow for compatibility between Dash and Dash Bio, as the former has upgraded to React 16.

Dash 1.0.0 (and the other Dash core libraries) includes an upgrade to React 16.6.1 (https://github.com/plotly/dash/issues/469), which will be reflected in dash-bio when `dash-1.0.0` is released. 

## Description of changes
* Upgrade `react` version to `16.0.0`
* Upgrade `react-dom` version to `16.0.0`
* Upgrade `dash` version to latest (`0.43.0`)

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)
