### PR TITLE
Mol2d proptypes fix

### DIFF
--- a/dash_bio/package-info.json
+++ b/dash_bio/package-info.json
@@ -1,1 +1,1 @@
-{"name": "dash_bio", "version": "0.1.2rc5", "author": "The Plotly Team <dashbio@plot.ly>"}
+{"name": "dash_bio", "version": "0.1.2rc6", "author": "The Plotly Team <dashbio@plot.ly>"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8994,12 +8994,12 @@
       }
     },
     "molecule-2d-for-react": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/molecule-2d-for-react/-/molecule-2d-for-react-0.2.3.tgz",
-      "integrity": "sha1-8yMAe2lBHVFq5KwHgsRs6SyEVdk=",
+      "version": "git://github.com/plotly/molecule-2d-for-react.git#6f4e544d251aed00e85b77ab9731470e3d20b2b8",
+      "from": "git://github.com/plotly/molecule-2d-for-react.git",
       "requires": {
         "d3": "^4.1.1",
-        "react": "^15.3.2",
+        "prop-types": "^15.7.2",
+        "react": "^15.5.0",
         "react-dom": "^15.3.2"
       },
       "dependencies": {
@@ -9050,6 +9050,16 @@
             "d3-interpolate": "1",
             "d3-selection": "1",
             "d3-transition": "1"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
           }
         }
       }
@@ -10905,6 +10915,11 @@
       "requires": {
         "prop-types": "^15.5.8"
       }
+    },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.1.2rc5",
+  "version": "0.1.2rc6",
   "description": "Dash components for bioinformatics",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "circos": "^2.1.0",
     "fast-memoize": "^2.5.1",
     "ideogram": "git+https://github.com/eweitz/ideogram.git#7d9b2ab91b91ef35db93bdeb529d4760de63292f",
-    "molecule-2d-for-react": "^0.2.3",
+    "molecule-2d-for-react": "git://github.com/plotly/molecule-2d-for-react.git",
     "molecule-3d-for-react": "git://github.com/plotly/molecule-3d-for-react.git",
     "plotly.js": "^1.47.4",
     "ramda": "^0.26.0",


### PR DESCRIPTION
## About 

* Changed dependency for molecule-2d-for-react to the Plotly fork, which uses external `prop-types`. 