### PR TITLE
Mol3d default props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Updated dash_bio_utils to version that introduced standardization of
   data parsers.
 
+### Added
+* Added default props to Molecule3dViewer component.
+
 ## [0.1.1] - 2019-06-06
 
 ### Added

--- a/dash_bio/metadata.json
+++ b/dash_bio/metadata.json
@@ -1955,21 +1955,33 @@
           ]
         },
         "required": false,
-        "description": "The selection type - may be atom, residue or chain"
+        "description": "The selection type - may be atom, residue or chain",
+        "defaultValue": {
+          "value": "'atom'",
+          "computed": false
+        }
       },
       "backgroundColor": {
         "type": {
           "name": "string"
         },
         "required": false,
-        "description": "Property to change the background color of the molecule viewer"
+        "description": "Property to change the background color of the molecule viewer",
+        "defaultValue": {
+          "value": "'#FFFFFF'",
+          "computed": false
+        }
       },
       "backgroundOpacity": {
         "type": {
           "name": "number"
         },
         "required": false,
-        "description": "Property to change the backgroun opacity - ranges from 0 to 1"
+        "description": "Property to change the backgroun opacity - ranges from 0 to 1",
+        "defaultValue": {
+          "value": "0",
+          "computed": false
+        }
       },
       "styles": {
         "type": {

--- a/dash_bio/package-info.json
+++ b/dash_bio/package-info.json
@@ -1,1 +1,1 @@
-{"name": "dash_bio", "version": "0.1.2rc6", "author": "The Plotly Team <dashbio@plot.ly>"}
+{"name": "dash_bio", "version": "0.1.2rc7", "author": "The Plotly Team <dashbio@plot.ly>"}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.1.2rc6",
+  "version": "0.1.2rc7",
   "description": "Dash components for bioinformatics",
   "repository": {
     "type": "git",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # pip install -r requirements.txt
 cython>=0.19
 dash==0.40.0
-dash-bio==0.1.2rc5
+dash-bio==0.1.2rc7
 dash-bio-utils==0.0.3rc3
 dash-daq==0.1.4
 gunicorn==19.9.0

--- a/src/lib/components/Molecule3dViewer.js
+++ b/src/lib/components/Molecule3dViewer.js
@@ -45,7 +45,10 @@ export default class Molecule3dViewer extends Component {
         // capitalized, but Dash typically uses all-lowercase prop values
 
         const capitalizedSelectionType =
-            selectionType.charAt(0).toUpperCase() + selectionType.slice(1);
+            selectionType === null
+                ? null
+                : selectionType.charAt(0).toUpperCase() +
+                  selectionType.slice(1);
 
         return (
             <div id={id}>

--- a/src/lib/components/Molecule3dViewer.js
+++ b/src/lib/components/Molecule3dViewer.js
@@ -60,6 +60,12 @@ export default class Molecule3dViewer extends Component {
     }
 }
 
+Molecule3dViewer.defaultProps = {
+    selectionType: 'atom',
+    backgroundColor: '#FFFFFF',
+    backgroundOpacity: 0,
+};
+
 Molecule3dViewer.propTypes = {
     /**
      * The ID used to identify this component in callbacks


### PR DESCRIPTION
Closes #376 

## About
- [ ] This is a new component
- [ ] I am adding a feature to an existing component, or improving an existing feature
- [x] I am closing an issue

## Description of changes
* Added default props for Molecule3dViewer: `selectionType`, `backgroundColor`, and `backgroundOpacity`. 
* Handled case in which `selectionType` is null (this was previously causing an error if the prop had an undefined value, since it assumes that the prop is a string. 

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)
