### PR TITLE
Allow any version of Dash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
                     python -m venv venv
                     . venv/bin/activate
                     pip install --upgrade pip
-                    pip install dash==0.40.0
+                    pip install dash>=0.40.0
                     npm run build:py
 
 

--- a/dash_bio/Circos.py
+++ b/dash_bio/Circos.py
@@ -52,7 +52,7 @@ please check the docs."""
         _locals.update(kwargs)  # For wildcard attrs
         args = {k: _locals[k] for k in _explicit_args if k != 'children'}
 
-        for k in ['layout']:
+        for k in [u'layout']:
             if k not in args:
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')

--- a/dash_bio/Ideogram.py
+++ b/dash_bio/Ideogram.py
@@ -160,7 +160,7 @@ e.g., for mitochondrial (MT) and chloroplast (CP) DNA."""
         _locals.update(kwargs)  # For wildcard attrs
         args = {k: _locals[k] for k in _explicit_args if k != 'children'}
 
-        for k in ['id']:
+        for k in [u'id']:
             if k not in args:
                 raise TypeError(
                     'Required argument `' + k + '` was not specified.')

--- a/dash_bio/package-info.json
+++ b/dash_bio/package-info.json
@@ -1,1 +1,1 @@
-{"name": "dash_bio", "version": "0.1.2", "author": "The Plotly Team <dashbio@plot.ly>"}
+{"version": "0.1.3rc2", "name": "dash_bio", "author": "The Plotly Team <dashbio@plot.ly>"}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.1.2",
+  "version": "0.1.3rc2",
   "description": "Dash components for bioinformatics",
   "repository": {
     "type": "git",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # pip install -r requirements.txt
 cython>=0.19
 dash==0.40.0
-dash-bio==0.1.2
+dash-bio==0.1.3rc2
 dash-bio-utils==0.0.3rc3
 dash-daq==0.1.4
 gunicorn==19.9.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'dash',
+        'dash>=0.40.0',
         'pandas',
         'plotly',
         'scipy',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'dash==0.40.0',
+        'dash',
         'pandas',
         'plotly',
         'scipy',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,6 @@
 
 # Additional packages needed to run the tests.
 chromedriver-binary==2.45.0
-dash==0.40.0
 flake8==3.6.0
 ipdb==0.11
 percy==2.0.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,7 @@
 
 # Additional packages needed to run the tests.
 chromedriver-binary==2.45.0
+dash==0.40.0
 flake8==3.6.0
 ipdb==0.11
 percy==2.0.1


### PR DESCRIPTION
Closes https://github.com/plotly/dash-docs/issues/598

## About

- [x] I am closing an issue

## Description of changes

Right now, Dash Bio is incompatible with newer versions of Dash including that which we use in documentation. Ideally, component libraries have a loose dependency on Dash - the user should be able to upgrade and install Dash independently of the component package, and the component package shouldn't have to create a new release with every release of Dash.

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)
