### PR TITLE
0.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Changelog
 
-## [0.1.2] - 
+## [0.1.2] - 2019-07-13
 
 ### Changed
 * Made Speck component compatible with refactored Speck library.
 * Optimized Speck component further to increase performance.
-* Updated dash_bio_utils to version that introduced standardization of
-  data parsers.
-* Changed Circos source from NPM to GitHub fork.
 
 ### Added
 * Added default props to Molecule3dViewer component.

--- a/dash_bio/package-info.json
+++ b/dash_bio/package-info.json
@@ -1,1 +1,1 @@
-{"name": "dash_bio", "version": "0.1.2rc9", "author": "The Plotly Team <dashbio@plot.ly>"}
+{"name": "dash_bio", "version": "0.1.2", "author": "The Plotly Team <dashbio@plot.ly>"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.1.2rc8",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bio",
-  "version": "0.1.2rc9",
+  "version": "0.1.2",
   "description": "Dash components for bioinformatics",
   "repository": {
     "type": "git",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # pip install -r requirements.txt
 cython>=0.19
 dash==0.40.0
-dash-bio==0.1.2rc9
+dash-bio==0.1.2
 dash-bio-utils==0.0.3rc3
 dash-daq==0.1.4
 gunicorn==19.9.0


### PR DESCRIPTION
Removed the CHANGELOG entries related to the version of `dash_bio_utils` (not related to the actual library, but related to the demo apps) and moving the package location for Circos (irrelevant to the functionality of the package).