### PR TITLE
Reformat generated components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
                     . venv/bin/activate
                     pip install --upgrade pip
                     pip install dash>=0.40.0
+                    pip install black
                     npm run build:py
 
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint src --fix",
     "build:js-dev": "webpack --mode development",
     "build:js": "npm run lint & npm run format & webpack --mode production",
-    "build:py": "node ./extract-meta src/lib/components > dash_bio/metadata.json && python get_version_info.py && python -c \"import dash; dash.development.component_loader.generate_classes('dash_bio', 'dash_bio/metadata.json')\"",
+    "build:py": "node ./extract-meta src/lib/components > dash_bio/metadata.json && python get_version_info.py && python -c \"import dash; dash.development.component_loader.generate_classes('dash_bio', 'dash_bio/metadata.json')\" && black dash_bio",
     "build:all": "npm run build:js & npm run build:py",
     "build:all-dev": "npm run build:js-dev & npm run build:py"
   },

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,7 @@
 -r ../requirements.txt
 
 # Additional packages needed to run the tests.
+black==19.3b0
 chromedriver-binary==2.45.0
 flake8==3.6.0
 ipdb==0.11


### PR DESCRIPTION
Closes https://github.com/plotly/dash-bio/pull/411#discussion_r324820104.

## About
I am running `black` on generated components to reformat them.

## Description of changes
I am adding it to our `build:py` command.

I am happy to wait until #411 is merged...

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)
