### PR TITLE
Let CI run Python unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,13 @@ jobs:
                     pip install -e .
                     pytest tests/integration
 
+            - run:
+                name: Run unit tests
+                command: |
+                    python -m venv venv
+                    . venv/bin/activate
+                    pytest tests/unit
+
     python-3.7:
         <<: *test-template
         docker:


### PR DESCRIPTION
Closes #462.

## About
- [ ] This is a new component
- [ ] I am adding a feature to an existing component, or improving an existing feature
- [x] I am closing an issue

## Description of changes
~I was quite tempted to add a Python command right next to `python unit_test_data_setup.py`. Instead, should we separate Python unit tests and JS unit tests into two different steps?~
Oops, that step of running Python unit tests definitely can't be part of a `node` job! I have rebased.

## Before merging
- [ ] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [ ] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [ ] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)
