### PR TITLE
fix: use correct path for apps modified

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
         - run:
             name: Deploy
             command: |
-              APPS_MODIFIED=$(git diff origin/master origin/$CIRCLE_BRANCH --dirstat=files,1 tests/dashbio_demos/ | awk '{ split($2,a,"/"); if (length(a[3]) != 0) { print a[3]} } ' | grep dash- |sort -u)
+              APPS_MODIFIED=$(git diff origin/master origin/$CIRCLE_BRANCH --dirstat=files,1 tests/dashbio_demos/ | awk '{ split($2,a,"/"); if (length(a[3]) != 0) { print a[3]} } ' | grep dash- | sort -u || true)
               if [ -z "$APPS_MODIFIED" ]
               then
                     echo "No app change detected. Skipping the deploy.."
@@ -204,7 +204,7 @@ jobs:
         - run:
             name: Deploy
             command: |
-              APPS_MODIFIED=$(ls apps | grep dash- | sort -u)
+              APPS_MODIFIED=$(ls tests/dashbio_demos | grep dash- | sort -u)
               if [ -z "$APPS_MODIFIED" ]
               then
                     echo "No app change detected. Skipping the deploy.."


### PR DESCRIPTION
## About
- [x] I am adding a feature to an existing component, or improving an existing feature

## Description of changes

The path to the modified apps for dash-gallery deploys was incorrect, so this change fixes that.

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)
