### PR TITLE
fix: correct case where pre-existing history conflicts with new changes

### DIFF
--- a/deploy
+++ b/deploy
@@ -149,6 +149,10 @@ main() {
 
   log-header "Ensuring code is up to date"
   log-info "Copying updated app source"
+  pushd "$tmp_full_clone" >/dev/null
+  find -not -path "./.git/*" -not -name ".git" -delete 2> /dev/null
+  popd >/dev/null
+
   pushd "$app_dir" >/dev/null
   cp -Rfp * "$tmp_full_clone"
   [[ -f .buildpacks ]] && cp -fp .buildpacks "$tmp_full_clone/.buildpacks"


### PR DESCRIPTION
## About
- [x] I am closing an issue

## Description of changes

Some of the apps had pre-existing history, which ended up being merged - and not overwritten - with the new app history. This change was pulled from dash-sample-apps, where I saw this exact issue last week.

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)
