### PR TITLE
fix: add missing layout_helper file

### DIFF
--- a/deploy
+++ b/deploy
@@ -164,6 +164,7 @@ main() {
     cp -p "$SOURCE_DIR/app.json" "$tmp_full_clone/app.json"
     cp -p "$SOURCE_DIR/predeploy.py" "$tmp_full_clone/predeploy.py"
     cp -p "$SOURCE_DIR/runtime.txt" "$tmp_full_clone/runtime.txt"
+    cp -p "$APPS_DIR/common/layout_helper.py" "$tmp_full_clone/layout_helper.py"
     pushd "$APPS_DIR/common/assets" >/dev/null
     cp -p * "$tmp_full_clone/assets"
     popd >/dev/null


### PR DESCRIPTION
## About
- [x] Fixing a bug

## Description of changes

This ensures we have the common layout_helper file in all apps.

## Before merging
- [x] I have gone through the [code review checklist](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/review_checklist.md)
- [x] I have completed all of the [steps to take before merging](https://github.com/plotly/dash-bio/blob/master/.github/before_merging.md)
- [x] I know how to [deploy to DDS](https://github.com/plotly/dash-bio/blob/master/.github/deploying_to_dds.md)
