### PR TITLE
fix Circos plot bug, now shows plot immediately

### DIFF
--- a/tests/dashbio_demos/dash-circos/app.py
+++ b/tests/dashbio_demos/dash-circos/app.py
@@ -914,6 +914,7 @@ def layout():
         )),
 
         html.Div(id='circos-control-tabs', className='control-tabs', children=[
+            dt.DataTable(),
             dcc.Tabs(id='circos-tabs', value='what-is', children=[
                 dcc.Tab(
                     label='About',


### PR DESCRIPTION
Addresses this issue from Dash Sample Apps: https://github.com/plotly/dash-sample-apps/issues/362


## About
- [x] I am closing an issue
- [ ] This is a new component
- [ ] I am adding a feature to an existing component, or improving an existing feature

## Description of changes
The Circos plot would not be visible until the user clicked on the 'Table' tab. Once this tab was triggered, then the plot would show up no matter which tab was clicked on. The callback that was responsible for displaying the plot was blocked by the data table inside the 'Table' tab. 

Here is a very similar issue: https://github.com/plotly/dash/issues/1010 (Thank you to @michaelbabyn for showing me this).

In order to combat this, I created an empty datable just before dcc.Tabs was declared. Now this app functions as intended.