### PR TITLE
graph_objs --> graph_objects

### DIFF
--- a/dash_bio/component_factory/_clustergram.py
+++ b/dash_bio/component_factory/_clustergram.py
@@ -8,7 +8,7 @@ import scipy.cluster.hierarchy as sch
 import scipy.spatial as scs
 from sklearn.impute import SimpleImputer
 
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 from plotly import tools
 
 
@@ -145,10 +145,10 @@ Keyword arguments:
     'color' (a string representation of the color of the
     annotation).
 - tick_font (dict; optional): The font options for ticks, as specified
-    in the Plotly graph_objs documentation (see:
+    in the Plotly graph_objects documentation (see:
     https://plot.ly/python/reference/#bar-marker-colorbar-tickfont).
 - annotation_font (dict; optional): The font options for annotations,
-    as specified in the Plotly graph_objs documentation (see:
+    as specified in the Plotly graph_objects documentation (see:
     https://plot.ly/python/reference/#layout-scene-annotations-items-annotation-font).
 - line_width (list | number; default 0.5): The line width for the
     dendrograms. If in list format, the first element corresponds to
@@ -197,7 +197,7 @@ class _Clustergram:
 
 Methods:
 
-- figure(computed_traces=None): Return a figure object compatible with plotly.graph_objs.
+- figure(computed_traces=None): Return a figure object compatible with plotly.graph_objects.
     """
 
     def __init__(
@@ -346,7 +346,7 @@ Methods:
             self._data = self._scale(standardize)
 
     def figure(self, computed_traces=None):
-        """Return a figure object compatible with plotly.graph_objs.
+        """Return a figure object compatible with plotly.graph_objects.
 
     Parameters:
 

--- a/dash_bio/component_factory/_manhattan.py
+++ b/dash_bio/component_factory/_manhattan.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
 from .utils import _get_hover_text
 
@@ -88,7 +88,7 @@ Keyword arguments:
     should be shown.
 - col (string; optional): A string representing the color of the
     points of the scatter plot. Can be in any color format accepted by
-    plotly.graph_objs.
+    plotly.graph_objects.
 - suggestiveline_value (bool | float; default 8): A value which must
     be either False to deactivate the option, or a numerical value
     corresponding to the p-value at which the line should be drawn.
@@ -102,14 +102,14 @@ Keyword arguments:
     corresponding to the p-value above which the data points are
     considered significant.
 - genomewideline_color (string; default 'red'): Color of the genome-wide
-    line. Can be in any color format accepted by plotly.graph_objs.
+    line. Can be in any color format accepted by plotly.graph_objects.
 - genomewideline_width (number; default 1): Width of the genome-wide
   line.
 - highlight (bool; default True): turning on/off the highlighting of
     data points considered significant.
 - highlight_color (string; default 'red'): Color of the data points
     highlighted because they are significant. Can be in any color
-    format accepted by plotly.graph_objs.
+    format accepted by plotly.graph_objects.
 
     # ...
     Example 1: Random Manhattan Plot
@@ -379,7 +379,7 @@ class _ManhattanPlot():
         legends should be shown.
     - col (string; optional): A string representing the color of the
         points of the Scatter plot. Can be in any color format
-        accepted by plotly.graph_objs.
+        accepted by plotly.graph_objects.
     - suggestiveline_value (bool | float; default 8): A value which
         must be either False to deactivate the option, or a numerical value
         corresponding to the p-value at which the line should be
@@ -394,17 +394,17 @@ class _ManhattanPlot():
         data points are considered significant.
     - genomewideline_color (string; default 'red'): Color of the
         genome-wide line. Can be in any color format accepted by
-        plotly.graph_objs.
+        plotly.graph_objects.
     - genomewideline_width (number; default 1): Width of the genome
       wide line.
     - highlight (bool; default True): Whether to turn on or off the
         highlighting of data points considered significant.
     - highlight_color (string; default 'red'): Color of the data
         points highlighted because they are significant. Can be in any
-        color format accepted by plotly.graph_objs.
+        color format accepted by plotly.graph_objects.
 
     Returns:
-    - A figure formatted for plotly.graph_objs.
+    - A figure formatted for plotly.graph_objects.
 
         """
 

--- a/dash_bio/component_factory/_volcano.py
+++ b/dash_bio/component_factory/_volcano.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
 from .utils import _get_hover_text
 
@@ -78,7 +78,7 @@ Keyword arguments:
 - point_size (number; default 5): Size of the points of the Scatter
     plot.
 - col (string; optional): Color of the points of the Scatter plot. Can
-    be in any color format accepted by plotly.graph_objs.
+    be in any color format accepted by plotly.graph_objects.
 - effect_size_line (bool | list; default [-1, 1]): A boolean which
     must be either False to deactivate the option, or a list/array containing
     the upper and lower bounds of the effect size values. Significant
@@ -95,14 +95,14 @@ Keyword arguments:
     points are considered significant.
 - genomewideline_color (string; default 'red'): Color of the
     genome-wide line. Can be in any color format accepted by
-    plotly.graph_objs.
+    plotly.graph_objects.
 - genomewideline_width (number; default 1): Width of the genome-wide
     line.
 - highlight (bool; default True): Whether the data points considered
     significant should be highlighted or not.
 - highlight_color (string; default 'red'): Color of the data points
     highlighted because considered significant. Can be in any color
-    format accepted by plotly.graph_objs.
+    format accepted by plotly.graph_objects.
 
     # ...
     Example 1: Random Volcano Plot
@@ -288,7 +288,7 @@ class _VolcanoPlot():
             highlight=True,
             highlight_color='red',
     ):
-        """Return a figure object compatible with plotly.graph_objs.
+        """Return a figure object compatible with plotly.graph_objects.
 
         Keyword arguments:
     - title (string; default 'Volcano Plot'): Title of the
@@ -298,7 +298,7 @@ class _VolcanoPlot():
     - point_size (number; default 5): Size of the points of the scatter
       plot.
     - col (string; optional): Color of the points of the Scatter plot. Can
-        be in any color format accepted by plotly.graph_objs.
+        be in any color format accepted by plotly.graph_objects.
     - effect_size_line (bool | list; default [-1, 1]): A boolean which must be
         either False to deactivate the option, or a list/array containing the
         upper and lower bounds of the effect size values. Significant data
@@ -314,14 +314,14 @@ class _VolcanoPlot():
         numerical value corresponding to the p-value above which the
         data points are considered significant.
     - genomewideline_color (string; default 'red'): Color of the genome-wide
-        line. Can be in any color format accepted by plotly.graph_objs.
+        line. Can be in any color format accepted by plotly.graph_objects.
     - genomewideline_width (number; default 1): Width of the genome-wide
         line.
     - highlight (bool; default True): Whether the data points considered
       significant should be highlighted or not.
     - highlight_color (string; default 'red'): Color of the data points
         highlighted because considered significant. Can be in any color
-        format accepted by plotly.graph_objs.
+        format accepted by plotly.graph_objects.
         """
 
         if xlabel is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jsonschema==2.6.0
 matplotlib==3.0.2
 numpy
 pandas>=0.24.2
-plotly>=3.5.0
+plotly>=4.1.0
 PubChemPy==1.0.4
 requests==2.21.0
 scikit-learn==0.20.2


### PR DESCRIPTION
This PR proposes to bump the plotly.py dependency to the 4.x series, and modifies accordingly some components with the new syntax `graph_objects` instead of `graph_objs`. (4.0 was released in July 2019)