### PR TITLE
Adding dockerhub authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,12 +136,9 @@ workflows:
   version: 2
   build:
     jobs:
-      - python-3.6
-          context:
-            - dash-docker-hub
-      - python-3.7
-          context:
-            - dash-docker-hub
-      - node
-          context:
-            - dash-docker-hub
+      - python-3.6:
+          context: dash-docker-hub
+      - python-3.7:
+          context: dash-docker-hub
+      - node:
+          context: dash-docker-hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,9 @@ jobs:
     node:
         docker:
             - image: circleci/python:3.7.5-stretch-node
-
+              auth:
+                username: dashautomation
+                password: $DASH_PAT_DOCKERHUB
         steps:
             - checkout
             - run:
@@ -51,7 +53,9 @@ jobs:
     python-3.6: &test-template
         docker:
             - image: circleci/python:3.6.9-stretch-node-browsers
-
+              auth:
+                username: dashautomation
+                password: $DASH_PAT_DOCKERHUB
         environment:
             PERCY_ENABLED: True
 
@@ -122,7 +126,9 @@ jobs:
         <<: *test-template
         docker:
             - image: circleci/python:3.7.5-stretch-node-browsers
-
+              auth:
+                username: dashautomation
+                password: $DASH_PAT_DOCKERHUB
         environment:
             PERCY_ENABLED: True
 
@@ -131,5 +137,8 @@ workflows:
   build:
     jobs:
       - python-3.6
+          context: dash-docker-hub
       - python-3.7
+          context: dash-docker-hub
       - node
+          context: dash-docker-hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,11 @@ workflows:
   build:
     jobs:
       - python-3.6
-          context: dash-docker-hub
+          context:
+            - dash-docker-hub
       - python-3.7
-          context: dash-docker-hub
+          context:
+            - dash-docker-hub
       - node
-          context: dash-docker-hub
+          context:
+            - dash-docker-hub


### PR DESCRIPTION


## About
- [x] I am addressing part of an issue

## Description of changes

This PR addresses the `dash-bio` component of plotly/dash-core#282, and adds authentication for Dockerhub requests for CI testing. The Circle CI `config.yml` is modified with the `dashAutomation` account details.