### PR TITLE
Fixing CI config for Rust install in `dash`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,12 +54,12 @@ jobs:
             - run:
                 name: Install Dash for package build and build package
                 command: |
-                    pip install --upgrade pip
                     curl --proto '=https' --tlsv1.2 -sSf -o rust-init.sh https://sh.rustup.rs
                     chmod ugo+x rust-init.sh
                     ./rust-init.sh -y
                     python -m venv venv
                     . venv/bin/activate
+                    pip install --upgrade pip
                     git clone --depth 1 https://github.com/plotly/dash.git dash-main
                     export PATH=$PATH:/home/circleci/.local/bin/:/home/circleci/.cargo/bin
                     export RUSTC_BOOTSTRAP=1
@@ -113,11 +113,11 @@ jobs:
             - run:
                 name: Install Dash
                 command: |
-                    pip install --upgrade pip
                     curl --proto '=https' --tlsv1.2 -sSf -o rust-init.sh https://sh.rustup.rs
                     chmod ugo+x rust-init.sh
                     ./rust-init.sh -y
                     . venv/bin/activate
+                    pip install --upgrade pip
                     git clone --depth 1 https://github.com/plotly/dash.git dash-main
                     export PATH=$PATH:/home/circleci/.local/bin/:/home/circleci/.cargo/bin
                     export RUSTC_BOOTSTRAP=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
             - run:
                 name: Install Dash for package build and build package
                 command: |
+                    pip install --upgrade pip
                     curl --proto '=https' --tlsv1.2 -sSf -o rust-init.sh https://sh.rustup.rs
                     chmod ugo+x rust-init.sh
                     ./rust-init.sh -y
@@ -112,6 +113,7 @@ jobs:
             - run:
                 name: Install Dash
                 command: |
+                    pip install --upgrade pip
                     curl --proto '=https' --tlsv1.2 -sSf -o rust-init.sh https://sh.rustup.rs
                     chmod ugo+x rust-init.sh
                     ./rust-init.sh -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
             - run:
                 name: Install Dash
                 command: |
-                    pip install --upgrade pip
+                    . venv/bin/activate
                     git clone --depth 1 https://github.com/plotly/dash.git dash-main
                     cd dash-main && pip install -e .[dev,testing] --progress-bar off && renderer build && cd ../
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,6 @@ jobs:
             - run:
                 name: Install Dash
                 command: |
-                    . venv/bin/activate
                     pip install --upgrade pip
                     git clone --depth 1 https://github.com/plotly/dash.git dash-main
                     cd dash-main && pip install -e .[dev,testing] --progress-bar off && renderer build && cd ../

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,15 +54,10 @@ jobs:
             - run:
                 name: Install Dash for package build and build package
                 command: |
-                    curl --proto '=https' --tlsv1.2 -sSf -o rust-init.sh https://sh.rustup.rs
-                    chmod ugo+x rust-init.sh
-                    ./rust-init.sh -y
                     python -m venv venv
                     . venv/bin/activate
                     pip install --upgrade pip
                     git clone --depth 1 https://github.com/plotly/dash.git dash-main
-                    export PATH=$PATH:/home/circleci/.local/bin/:/home/circleci/.cargo/bin
-                    export RUSTC_BOOTSTRAP=1
                     cd dash-main && pip install -e .[dev,testing] --progress-bar off && renderer build && cd ../
                     npm run build
 
@@ -115,14 +110,9 @@ jobs:
             - run:
                 name: Install Dash
                 command: |
-                    curl --proto '=https' --tlsv1.2 -sSf -o rust-init.sh https://sh.rustup.rs
-                    chmod ugo+x rust-init.sh
-                    ./rust-init.sh -y
                     . venv/bin/activate
                     pip install --upgrade pip
                     git clone --depth 1 https://github.com/plotly/dash.git dash-main
-                    export PATH=$PATH:/home/circleci/.local/bin/:/home/circleci/.cargo/bin
-                    export RUSTC_BOOTSTRAP=1
                     cd dash-main && pip install -e .[dev,testing] --progress-bar off && renderer build && cd ../
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,14 @@ jobs:
             - run:
                 name: Install Dash for package build and build package
                 command: |
+                    curl --proto '=https' --tlsv1.2 -sSf -o rust-init.sh https://sh.rustup.rs
+                    chmod ugo+x rust-init.sh
+                    ./rust-init.sh -y
                     python -m venv venv
                     . venv/bin/activate
                     git clone --depth 1 https://github.com/plotly/dash.git dash-main
+                    export PATH=$PATH:/home/circleci/.local/bin/:/home/circleci/.cargo/bin
+                    export RUSTC_BOOTSTRAP=1
                     cd dash-main && pip install -e .[dev,testing] --progress-bar off && renderer build && cd ../
                     npm run build
 
@@ -107,8 +112,13 @@ jobs:
             - run:
                 name: Install Dash
                 command: |
+                    curl --proto '=https' --tlsv1.2 -sSf -o rust-init.sh https://sh.rustup.rs
+                    chmod ugo+x rust-init.sh
+                    ./rust-init.sh -y
                     . venv/bin/activate
                     git clone --depth 1 https://github.com/plotly/dash.git dash-main
+                    export PATH=$PATH:/home/circleci/.local/bin/:/home/circleci/.cargo/bin
+                    export RUSTC_BOOTSTRAP=1
                     cd dash-main && pip install -e .[dev,testing] --progress-bar off && renderer build && cd ../
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,8 +101,10 @@ jobs:
 
             - run:
                 name: Install requirements
+                no_output_timeout: 20m
                 command: |
                     . venv/bin/activate
+                    pip install --upgrade pip
                     pip install --progress-bar off -r tests/requirements.txt --quiet
 
             - save_cache:

--- a/dash_bio/component_factory/_clustergram.py
+++ b/dash_bio/component_factory/_clustergram.py
@@ -280,11 +280,11 @@ Methods:
         else:
             self._col_group_marker = col_group_marker
         if tick_font is None:
-            self._tick_font = dict()
+            self._tick_font = {}
         else:
             self._tick_font = tick_font
         if annotation_font is None:
-            self._annotation_font = dict()
+            self._annotation_font = {}
         else:
             self._annotation_font = annotation_font
         self._paper_bg_color = paper_bg_color


### PR DESCRIPTION
This PR adds some minor fixes to the CI config in relation to the addition of the `orjson` dependency in `dash-2.0.0`. 