### PR TITLE
Revert percy snapshot changes

### DIFF
--- a/tests/integration/common_features.py
+++ b/tests/integration/common_features.py
@@ -10,10 +10,6 @@ PASS = 'passed'
 FAIL = 'failed'
 
 
-def generate_identifier():
-    return str(time.time())[-4:]
-
-
 def process_value(
         value,
         data_type,
@@ -191,10 +187,8 @@ def _start_app_server(
 
     dash_duo.wait_for_element('#passfail')
 
-    identifier = generate_identifier()
-
     if take_snapshot:
-        dash_duo.percy_snapshot(f'{component_id}_{test_prop_name}_{test_prop_value}_{identifier}',
+        dash_duo.percy_snapshot(f'{component_id}_{test_prop_name}_{test_prop_value}',
                                 convert_canvases=True)
 
     assert dash_duo.find_element('#passfail').text == PASS

--- a/tests/integration/test_molecule3d.py
+++ b/tests/integration/test_molecule3d.py
@@ -8,7 +8,7 @@ import dash_html_components as html
 from dash_bio_utils import pdb_parser as parser, styles_parser as sparser
 import dash_bio
 
-from common_features import simple_app_layout, simple_app_callback, generate_identifier
+from common_features import simple_app_layout, simple_app_callback
 
 
 _model_data = None
@@ -55,8 +55,7 @@ def test_dbm3001_selection_type(dash_duo):
 
     dash_duo.wait_for_element_by_css_selector('.molecule-3d')
 
-    dash_duo.percy_snapshot('test-mol3d_selectionType_chain' + generate_identifier(),
-                            convert_canvases=True)
+    dash_duo.percy_snapshot('test-mol3d_selectionType_chain', convert_canvases=True)
 
 
 def test_dbm3002_rotate(dash_duo):
@@ -80,7 +79,7 @@ def test_dbm3002_rotate(dash_duo):
     ac = ActionChains(dash_duo.driver)
     ac.drag_and_drop_by_offset(mol3d, 100, 50).perform()
 
-    dash_duo.percy_snapshot('test-mol3d_rotate' + generate_identifier(), convert_canvases=True)
+    dash_duo.percy_snapshot('test-mol3d_rotate', convert_canvases=True)
 
 
 def test_dbm3003_selected_atom_ids(dash_duo):
@@ -140,4 +139,4 @@ def test_dbm3004_labels(dash_duo):
 
     dash_duo.wait_for_text_to_equal('#labels-output', 'first_text')
 
-    dash_duo.percy_snapshot('test-mol3d_labels' + generate_identifier(), convert_canvases=True)
+    dash_duo.percy_snapshot('test-mol3d_labels', convert_canvases=True)

--- a/tests/integration/test_ngl_moleculeviewer.py
+++ b/tests/integration/test_ngl_moleculeviewer.py
@@ -15,7 +15,7 @@ import dash_bio
 
 # from dash_bio_utils import pdb_parser as parser
 
-from common_features import simple_app_layout, simple_app_callback, generate_identifier
+from common_features import simple_app_layout, simple_app_callback
 
 _COMPONENT_ID = "test-ngl"
 data_path = "tests/dashbio_demos/dash-ngl-moleculeviewer/data/"
@@ -264,8 +264,7 @@ def modified_simple_app_callback(
 
     time.sleep(5)
     if take_snapshot:
-        dash_duo.percy_snapshot(f"{component_id}_{test_prop_name}_{test_prop_value}_"
-                                f"{generate_identifier()}", convert_canvases=True)
+        dash_duo.percy_snapshot(f"{component_id}_{test_prop_name}_{test_prop_value}", convert_canvases=True)
 
 
 def test_dbdn001_viewer_loaded(dash_duo):

--- a/tests/integration/test_pileup.py
+++ b/tests/integration/test_pileup.py
@@ -4,7 +4,7 @@ import dash_html_components as html
 import os
 import re
 
-from common_features import simple_app_layout, generate_identifier
+from common_features import simple_app_layout
 
 _COMPONENT_ID = 'mypileup'
 
@@ -92,8 +92,7 @@ def test_dbpu001_reference(dash_duo):
     assert _GEAR_ICON in tracks[0].text
 
     # Take a Percy snapshot to check that tracks are rendered correctly
-    dash_duo.percy_snapshot('test-pileup_reference' + generate_identifier(),
-                            convert_canvases=True)
+    dash_duo.percy_snapshot('test-pileup_reference', convert_canvases=True)
 
     # Check that feature track loaded
     tracks = dash_duo.find_elements('.features')

--- a/tests/integration/test_speck.py
+++ b/tests/integration/test_speck.py
@@ -8,7 +8,7 @@ import dash_bio
 import dash_html_components as html
 from dash_bio_utils import xyz_reader
 
-from common_features import simple_app_layout, simple_app_callback, generate_identifier
+from common_features import simple_app_layout, simple_app_callback
 
 _data = None
 
@@ -41,7 +41,7 @@ def test_dbsp001_rotate(dash_duo):
     ac.move_to_element(speck).drag_and_drop_by_offset(
         speck, 150, 200).perform()
 
-    dash_duo.percy_snapshot('test-speck_rotate' + generate_identifier(), convert_canvases=True)
+    dash_duo.percy_snapshot('test-speck_rotate', convert_canvases=True)
 
 
 def test_dbsp002_click_and_drag(dash_duo):
@@ -63,7 +63,7 @@ def test_dbsp002_click_and_drag(dash_duo):
     ac.move_to_element(speck).key_down(Keys.SHIFT).drag_and_drop_by_offset(
         speck, -50, 100).key_up(Keys.SHIFT).perform()
 
-    dash_duo.percy_snapshot('test-speck_click_and_drag' + generate_identifier(),
+    dash_duo.percy_snapshot('test-speck_click_and_drag',
                             convert_canvases=True)
 
 


### PR DESCRIPTION
This PR fixes the percy snapshots generation so that the base branch comparison is made with master rather than simply having new snapshots generated - however, if any tests fails, the entire workflow must be re-run with a new commit, or Percy tests will fail due to conflicting URLs being used for different builds.