### PR TITLE
remove numpy pin in demos

### DIFF
--- a/tests/dashbio_demos/common/requirements.txt
+++ b/tests/dashbio_demos/common/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-alignment-chart/requirements.txt
+++ b/tests/dashbio_demos/dash-alignment-chart/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-circos/requirements.txt
+++ b/tests/dashbio_demos/dash-circos/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-clustergram/requirements.txt
+++ b/tests/dashbio_demos/dash-clustergram/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-forna-container/requirements.txt
+++ b/tests/dashbio_demos/dash-forna-container/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-ideogram/requirements.txt
+++ b/tests/dashbio_demos/dash-ideogram/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-igv/requirements.txt
+++ b/tests/dashbio_demos/dash-igv/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-manhattan-plot/requirements.txt
+++ b/tests/dashbio_demos/dash-manhattan-plot/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-molecule-2d-viewer/requirements.txt
+++ b/tests/dashbio_demos/dash-molecule-2d-viewer/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-molecule-3d-viewer/requirements.txt
+++ b/tests/dashbio_demos/dash-molecule-3d-viewer/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-needle-plot/requirements.txt
+++ b/tests/dashbio_demos/dash-needle-plot/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-onco-print/requirements.txt
+++ b/tests/dashbio_demos/dash-onco-print/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-sequence-viewer/requirements.txt
+++ b/tests/dashbio_demos/dash-sequence-viewer/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-speck/requirements.txt
+++ b/tests/dashbio_demos/dash-speck/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-variant-map/requirements.txt
+++ b/tests/dashbio_demos/dash-variant-map/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4

--- a/tests/dashbio_demos/dash-volcano-plot/requirements.txt
+++ b/tests/dashbio_demos/dash-volcano-plot/requirements.txt
@@ -6,7 +6,7 @@ dash-daq==0.2.2
 gunicorn==19.9.0
 jsonschema==2.6.0
 matplotlib==3.0.2
-numpy==1.21.0
+numpy
 pandas>=0.24.2
 plotly>=3.5.0
 PubChemPy==1.0.4


### PR DESCRIPTION
`numpy` has an update that resulted in a million dependabot PRs. We can't accept those because newer `numpy` versions are restricted to Py3.8+ - but we can simply unpin it and folks will get the top version available for their Python version.

