### PR TITLE
Fix error in Manhattan plot for single chromosome

### DIFF
--- a/dash_bio/component_factory/_manhattan.py
+++ b/dash_bio/component_factory/_manhattan.py
@@ -527,10 +527,10 @@ class _ManhattanPlot():
                     else data[self.pName].values,
                     mode="markers",
                     showlegend=showlegend,
+                    name="Chr%i" % data[self.chrName].unique(),
                     marker={
                         'color': col[0],
                         'size': point_size,
-                        'name': "chr%i" % data[self.chrName].unique()
                     },
                     text=hover_text
                 )


### PR DESCRIPTION
When attempting to use ManhattanPlot on data containing a single chromosome, a runtime error is encountered. Seems it was previously reported in #486 but the cause was not determined. From looking at the code, it seems like the `name` parameter was incorrectly included inside the `marker` dict, when it should have been a direct kwarg.

I've also updated the capitalization to match the multi-chromosome case.