### PR TITLE
fix broken link

### DIFF
--- a/tests/dashbio_demos/dash-circos/app.py
+++ b/tests/dashbio_demos/dash-circos/app.py
@@ -952,7 +952,7 @@ def layout():
                         html.Div([
                             'For a look into Circos and the Circos API, please visit the '
                             'original repository ',
-                            html.A('here', href='https://github.com/nicgirault/circosJS)'),
+                            html.A('here', href='https://github.com/nicgirault/circosJS'),
                             '.'
                         ]),
 


### PR DESCRIPTION
## Description of changes

Fixed a broken link (it had a redundant character at the end)

The change is for this demo app: https://dash.gallery/dash-circos/