### PR TITLE
Update _manhattan.py

### DIFF
--- a/dash_bio/component_factory/_manhattan.py
+++ b/dash_bio/component_factory/_manhattan.py
@@ -566,7 +566,7 @@ class _ManhattanPlot():
                 chromo = tmp[self.chrName].unique()  # Get chromosome name
 
                 hover_text = _get_hover_text(
-                    data,
+                    tmp,
                     snpname=self.snpName,
                     genename=self.geneName,
                     annotationname=self.annotationName


### PR DESCRIPTION
Closes #760 

## About
- [x] I am closing an issue
- [ ] This is a new component
- [ ] I am adding a feature to an existing component, or improving an existing feature

## Description of changes

Fixing issue: ManhattanPlot: Incorrect tooltip information for all variants below threshold #760

Editing _manhattan.py, line 569: `data` -> `tmp` so that _get_hover_text returns hover text for a single dataframe row that corresponds to the processing variant.