### PR TITLE
fix single chromosome bug + add small test

### DIFF
--- a/dash_bio/component_factory/_manhattan.py
+++ b/dash_bio/component_factory/_manhattan.py
@@ -527,10 +527,10 @@ class _ManhattanPlot():
                     else data[self.pName].values,
                     mode="markers",
                     showlegend=showlegend,
+                    name="chr%i" % data[self.chrName].unique(),
                     marker={
                         'color': col[0],
-                        'size': point_size,
-                        'name': "chr%i" % data[self.chrName].unique()
+                        'size': point_size
                     },
                     text=hover_text
                 )

--- a/tests/integration/test_manhattan_plot.py
+++ b/tests/integration/test_manhattan_plot.py
@@ -176,3 +176,11 @@ def test_dbmp005_highlight_color(dash_duo):
         prop_value_type='string',
         take_snapshot=True
     )
+
+
+def test_single_chromosome_use_case():
+    df = _data.copy()
+    one_chromosome_data = df[df['CHR'] == 1]
+    dash_bio.ManhattanPlot(
+            dataframe=one_chromosome_data
+    )


### PR DESCRIPTION
## About
- [x] I am closing an issue

## Description of changes
While using dash-bio to create an interactive Manhattan plot, I noticed it fails if there is only one chromosome in the chromosome column (CHR).

Here is the error message:
```
~/site-packages/dash_bio/component_factory/_manhattan.py:153: in ManhattanPlot
    highlight_color=highlight_color
~/site-packages/dash_bio/component_factory/_manhattan.py:535: in figure
    text=hover_text
~/site-packages/plotly/graph_objs/_scattergl.py:2778: in __init__
    self["marker"] = _v
~/site-packages/plotly/basedatatypes.py:4828: in __setitem__
    self._set_compound_prop(prop, value)
~/site-packages/plotly/basedatatypes.py:5239: in _set_compound_prop
    val = validator.validate_coerce(val, skip_invalid=self._skip_invalid)
~/site-packages/_plotly_utils/basevalidators.py:2467: in validate_coerce
    v = self.data_class(v, skip_invalid=skip_invalid, _validate=_validate)
~/site-packages/plotly/graph_objs/scattergl/_marker.py:1420: in __init__
    self._process_kwargs(**dict(arg, **kwargs))
~/site-packages/plotly/basedatatypes.py:4354: in _process_kwargs
    raise err
E   ValueError: Invalid property specified for object of type plotly.graph_objs.scattergl.Marker: 'name'
E   
E   Did you mean "line"?
E   
E       Valid properties:
E           autocolorscale
E               Determines whether the colorscale is a default palette
E               (`autocolorscale: true`) or the palette determined by
E               `marker.colorscale`. Has an effect only if in
E               `marker.color`is set to a numerical array. In case
E               `colorscale` is unspecified or `autocolorscale` is
E               true, the default  palette will be chosen according to
E               whether numbers in the `color` array are all positive,
E               all negative or mixed.
E           cauto
E               Determines whether or not the color domain is computed
E               with respect to the input data (here in `marker.color`)
E               or the bounds set in `marker.cmin` and `marker.cmax`
E               Has an effect only if in `marker.color`is set to a
E               numerical array. Defaults to `false` when `marker.cmin`
E               and `marker.cmax` are set by the user.
E           cmax
E               Sets the upper bound of the color domain. Has an effect
E               only if in `marker.color`is set to a numerical array.
E               Value should have the same units as in `marker.color`
E               and if set, `marker.cmin` must be set as well.
E           cmid
E               Sets the mid-point of the color domain by scaling
E               `marker.cmin` and/or `marker.cmax` to be equidistant to
E               this point. Has an effect only if in `marker.color`is
E               set to a numerical array. Value should have the same
E               units as in `marker.color`. Has no effect when
E               `marker.cauto` is `false`.
E           cmin
E               Sets the lower bound of the color domain. Has an effect
E               only if in `marker.color`is set to a numerical array.
E               Value should have the same units as in `marker.color`
E               and if set, `marker.cmax` must be set as well.
E           color
E               Sets themarkercolor. It accepts either a specific color
E               or an array of numbers that are mapped to the
E               colorscale relative to the max and min values of the
E               array or relative to `marker.cmin` and `marker.cmax` if
E               set.
E           coloraxis
E               Sets a reference to a shared color axis. References to
E               these shared color axes are "coloraxis", "coloraxis2",
E               "coloraxis3", etc. Settings for these shared color axes
E               are set in the layout, under `layout.coloraxis`,
E               `layout.coloraxis2`, etc. Note that multiple color
E               scales can be linked to the same color axis.
E           colorbar
E               :class:`plotly.graph_objects.scattergl.marker.ColorBar`
E               instance or dict with compatible properties
E           colorscale
E               Sets the colorscale. Has an effect only if in
E               `marker.color`is set to a numerical array. The
E               colorscale must be an array containing arrays mapping a
E               normalized value to an rgb, rgba, hex, hsl, hsv, or
E               named color string. At minimum, a mapping for the
E               lowest (0) and highest (1) values are required. For
E               example, `[[0, 'rgb(0,0,255)'], [1, 'rgb(255,0,0)']]`.
E               To control the bounds of the colorscale in color space,
E               use`marker.cmin` and `marker.cmax`. Alternatively,
E               `colorscale` may be a palette name string of the
E               following list: Blackbody,Bluered,Blues,Cividis,Earth,E
E               lectric,Greens,Greys,Hot,Jet,Picnic,Portland,Rainbow,Rd
E               Bu,Reds,Viridis,YlGnBu,YlOrRd.
E           colorsrc
E               Sets the source reference on Chart Studio Cloud for
E               `color`.
E           line
E               :class:`plotly.graph_objects.scattergl.marker.Line`
E               instance or dict with compatible properties
E           opacity
E               Sets the marker opacity.
E           opacitysrc
E               Sets the source reference on Chart Studio Cloud for
E               `opacity`.
E           reversescale
E               Reverses the color mapping if true. Has an effect only
E               if in `marker.color`is set to a numerical array. If
E               true, `marker.cmin` will correspond to the last color
E               in the array and `marker.cmax` will correspond to the
E               first color.
E           showscale
E               Determines whether or not a colorbar is displayed for
E               this trace. Has an effect only if in `marker.color`is
E               set to a numerical array.
E           size
E               Sets the marker size (in px).
E           sizemin
E               Has an effect only if `marker.size` is set to a
E               numerical array. Sets the minimum size (in px) of the
E               rendered marker points.
E           sizemode
E               Has an effect only if `marker.size` is set to a
E               numerical array. Sets the rule for which the data in
E               `size` is converted to pixels.
E           sizeref
E               Has an effect only if `marker.size` is set to a
E               numerical array. Sets the scale factor used to
E               determine the rendered size of marker points. Use with
E               `sizemin` and `sizemode`.
E           sizesrc
E               Sets the source reference on Chart Studio Cloud for
E               `size`.
E           symbol
E               Sets the marker symbol type. Adding 100 is equivalent
E               to appending "-open" to a symbol name. Adding 200 is
E               equivalent to appending "-dot" to a symbol name. Adding
E               300 is equivalent to appending "-open-dot" or "dot-
E               open" to a symbol name.
E           symbolsrc
E               Sets the source reference on Chart Studio Cloud for
E               `symbol`.
E           
E   Did you mean "line"?
E   
E   Bad property path:
E   name
E   ^^^^
```
Looks like in this corner case, the "name" key is called in the marker dict which is unexpected and should be located directly as one of the expected go.Scattergl arguments.

<!-- If you are changing any of the demo apps, please specify the URL(s) of the app(s) in question. -->