### PR TITLE
Feature/clustergram zoom patches

### DIFF
--- a/dash_bio/component_factory/_clustergram.py
+++ b/dash_bio/component_factory/_clustergram.py
@@ -558,11 +558,11 @@ Methods:
             col_dendro_traces_max_y = np.concatenate(col_dendro_traces_y).max()
 
         # ensure that everything is aligned properly
-        # with the heatmap
+        # with the heatmap and dendrograms zoom synchronously
         yaxis9 = fig["layout"]["yaxis9"]  # pylint: disable=invalid-sequence-index
-        yaxis9.update(scaleanchor="y11")
+        yaxis9.update(scaleanchor="y11", matches="y11")
         xaxis3 = fig["layout"]["xaxis3"]  # pylint: disable=invalid-sequence-index
-        xaxis3.update(scaleanchor="x11")
+        xaxis3.update(scaleanchor="x11", matches="x11")
 
         if len(tickvals_col) == 0:
             tickvals_col = [10 * i + 5 for i in range(len(self._column_ids))]

--- a/dash_bio/component_factory/_clustergram.py
+++ b/dash_bio/component_factory/_clustergram.py
@@ -560,9 +560,9 @@ Methods:
         # ensure that everything is aligned properly
         # with the heatmap and dendrograms zoom synchronously
         yaxis9 = fig["layout"]["yaxis9"]  # pylint: disable=invalid-sequence-index
-        yaxis9.update(scaleanchor="y11", matches="y11")
+        yaxis9.update(matches="y11")
         xaxis3 = fig["layout"]["xaxis3"]  # pylint: disable=invalid-sequence-index
-        xaxis3.update(scaleanchor="x11", matches="x11")
+        xaxis3.update(matches="x11")
 
         if len(tickvals_col) == 0:
             tickvals_col = [10 * i + 5 for i in range(len(self._column_ids))]
@@ -592,10 +592,7 @@ Methods:
             tickfont=self._tick_font,
             showticklabels=True,
             side="right",
-            showline=False,
-            ticks="",
-            showgrid=False,
-            fixedrange=False
+            showline=False
         )
 
         # hide labels, if necessary
@@ -723,31 +720,15 @@ Methods:
             fig["layout"]["yaxis10"].update(
                 matches="y11",
                 range=[min(tickvals_row), max(tickvals_row)],
-                showticklabels=False,
-                ticks="",
-                showgrid=False,
                 tickmode="array",
                 tickvals=[],
                 ticktext=[]
             )
-        # Similar setup for column colors: (xaxis7 and xaxis6) match main heatmap x-axis (xaxis11)
+        # Similar setup for column colors: xaxis7 matches main heatmap x-axis (xaxis11)
         if len(tickvals_col) > 0:
             fig["layout"]["xaxis7"].update(
                 matches="x11",
                 range=[min(tickvals_col), max(tickvals_col)],
-                showticklabels=False,
-                ticks="",
-                showgrid=False,
-                tickmode="array",
-                tickvals=[],
-                ticktext=[]
-            )
-            fig["layout"]["xaxis6"].update(
-                matches="x11",
-                range=[min(tickvals_col), max(tickvals_col)],
-                showticklabels=False,
-                ticks="",
-                showgrid=False,
                 tickmode="array",
                 tickvals=[],
                 ticktext=[]

--- a/dash_bio/component_factory/_clustergram.py
+++ b/dash_bio/component_factory/_clustergram.py
@@ -576,9 +576,10 @@ Methods:
             showticklabels=True,
             side="bottom",
             showline=False,
-            range=[min(tickvals_col) - 5, max(tickvals_col) + 5]
+            range=[min(tickvals_col) - 5, max(tickvals_col) + 5],
             # workaround for autoscale issues above; otherwise
             # the graph cuts off and must be scaled manually
+            fixedrange=False
         )
 
         if len(tickvals_row) == 0:
@@ -592,17 +593,20 @@ Methods:
             showticklabels=True,
             side="right",
             showline=False,
+            ticks="",
+            showgrid=False,
+            fixedrange=False
         )
 
         # hide labels, if necessary
         for label in self._hidden_labels:
             fig["layout"][label].update(ticks="", showticklabels=False)
 
-        row_colors_heatmap = self._get_row_colors_heatmap()
+        row_colors_heatmap = self._get_row_colors_heatmap(tickvals_row)
         if row_colors_heatmap is not None:
-            fig.append_trace(self._get_row_colors_heatmap(), 3, 2)
+            fig.append_trace(row_colors_heatmap, 3, 2)
 
-        col_colors_heatmap = self._get_column_colors_heatmap()
+        col_colors_heatmap = self._get_column_colors_heatmap(tickvals_col)
         if col_colors_heatmap is not None:
             fig.append_trace(col_colors_heatmap, 2, 3)
 
@@ -711,6 +715,43 @@ Methods:
         fig["layout"]["yaxis11"].update(  # pylint: disable=invalid-sequence-index
             domain=[0, 1 - col_ratio - col_colors_ratio]
         )
+
+        # Link color heatmap axes to main heatmap for zoom synchronization
+        # Using 'matches' to ensure the same coordinate system
+        # Row colors (yaxis10) matches main heatmap y-axis (yaxis11)
+        if len(tickvals_row) > 0:
+            fig["layout"]["yaxis10"].update(
+                matches="y11",
+                range=[min(tickvals_row), max(tickvals_row)],
+                showticklabels=False,
+                ticks="",
+                showgrid=False,
+                tickmode="array",
+                tickvals=[],
+                ticktext=[]
+            )
+        # Similar setup for column colors: (xaxis7 and xaxis6) match main heatmap x-axis (xaxis11)
+        if len(tickvals_col) > 0:
+            fig["layout"]["xaxis7"].update(
+                matches="x11",
+                range=[min(tickvals_col), max(tickvals_col)],
+                showticklabels=False,
+                ticks="",
+                showgrid=False,
+                tickmode="array",
+                tickvals=[],
+                ticktext=[]
+            )
+            fig["layout"]["xaxis6"].update(
+                matches="x11",
+                range=[min(tickvals_col), max(tickvals_col)],
+                showticklabels=False,
+                ticks="",
+                showgrid=False,
+                tickmode="array",
+                tickvals=[],
+                ticktext=[]
+            )
 
         fig["layout"][
             "legend"
@@ -833,7 +874,7 @@ Methods:
 
         return (Zcol, Zrow)
 
-    def _get_row_colors_heatmap(self):
+    def _get_row_colors_heatmap(self, tickvals_row=None):
         colors = self._row_colors
 
         if colors is None:
@@ -854,14 +895,21 @@ Methods:
 
         z = [[i] for i in range(len(colors))]
 
-        return go.Heatmap(
-            z=z,
-            colorscale=colorscale,
-            colorbar={"xpad": 100},
-            showscale=False
-        )
+        heatmap_kwargs = {
+            "z": z,
+            "colorscale": colorscale,
+            "colorbar": {"xpad": 100},
+            "showscale": False
+        }
 
-    def _get_column_colors_heatmap(self):
+        # Use the same y-coordinates as the main heatmap for proper
+        # zoom synchronization
+        if tickvals_row is not None:
+            heatmap_kwargs["y"] = tickvals_row
+
+        return go.Heatmap(**heatmap_kwargs)
+
+    def _get_column_colors_heatmap(self, tickvals_col=None):
         colors = self._column_colors
 
         if colors is None:
@@ -882,12 +930,19 @@ Methods:
 
         z = [[i * 5 for i in range(len(colors))]]
 
-        return go.Heatmap(
-            z=z,
-            colorscale=colorscale,
-            colorbar={"xpad": 100},
-            showscale=False
-        )
+        heatmap_kwargs = {
+            "z": z,
+            "colorscale": colorscale,
+            "colorbar": {"xpad": 100},
+            "showscale": False
+        }
+
+        # Use the same x-coordinates as the main heatmap for proper
+        # zoom synchronization
+        if tickvals_col is not None:
+            heatmap_kwargs["x"] = tickvals_col
+
+        return go.Heatmap(**heatmap_kwargs)
 
     def _compute_clustered_data(self):
         """Get the traces that need to be plotted for the row and column


### PR DESCRIPTION
## Overview
Closes #780 and closes #778 related to bugs with Clustergram zooming behavior.

## About
- [X] I am closing an issue
- [ ] This is a new component
- [X] I am adding a feature to an existing component, or improving an existing feature

## Description of changes

This PR fixes two related zoom synchronization bugs in the Clustergram component:

  ### 1. Fix column_colors and row_colors zoom synchronization
  **Problem**: When zooming into a region of the heatmap, the `column_colors` and `row_colors` annotation bars were remaining at their original scale rather than zooming in to match the selected region. This made it impossible to identify which color annotations corresponded to the zoomed cells (Issue #780).

  **Solution Implemented**:
  - Modified `_get_row_colors_heatmap()` and `_get_column_colors_heatmap()` to accept `tickvals` parameters and use the same coordinate system as the main heatmap.
  - Added `matches` parameter to link color heatmap axes (xaxis6, xaxis7 for column colors; yaxis10 for row colors) with the main heatmap axes (xaxis11, yaxis11).

  ### 2. Fix dendrogram zoom synchronization
  **Problem**: When zooming into the heatmap, the dendrograms would zoom, but display an incorrect portion of the dendrogram not actually corresponding to the selected heatmap region, as thoroughly documented with examples in Issue #778. 

  **Solution**:
  - Added `matches` parameter to dendrogram axes in addition to the existing `scaleanchor` parameter
  - Row dendrogram y-axis (yaxis9) now uses `matches="y11"` to synchronize with heatmap y-axis
  - Column dendrogram x-axis (xaxis3) now uses `matches="x11"` to synchronize with heatmap x-axis

  **Technical details**: The key difference is that `scaleanchor` only maintains the scale/aspect ratio between axes, while `matches` ensures axes share the same coordinate system and zoom level. Both are needed for dendrogram zooming to work properly: `scaleanchor` ensures proper visual alignment and `matches` is necessary for synchronized zooming.

## Example and screenshots
Example Clustergram:
```
import pandas as pd
from dash import Dash, html, dcc
import dash_bio as dashbio

app = Dash(__name__)

df = pd.read_csv('https://git.io/clustergram_brain_cancer.csv').set_index('ID_REF')
rows = list(df.index)[:15]

column_colors = ['red', 'blue', 'green', 'yellow', 'purple',
                 'orange', 'pink', 'cyan', 'magenta', 'brown',
                 'red', 'blue', 'green', 'yellow', 'purple']

row_colors = ['red', 'blue', 'green', 'yellow', 'purple',
              'orange', 'pink', 'cyan', 'magenta', 'brown',
              'red', 'blue', 'green', 'yellow', 'purple',
              'orange', 'pink', 'cyan', 'magenta', 'brown']

app.layout = html.Div([
    dcc.Graph(figure=dashbio.Clustergram(
        data=df.loc[rows].values,
        column_colors=column_colors,
        row_colors=row_colors,
        color_threshold={
            'row': 250,
            'col': 700
        },
        height=800,
        width=700
    ))
])

if __name__ == '__main__':
    app.run(debug=True, port=8060)
```
<img width="606" height="742" alt="image" src="https://github.com/user-attachments/assets/0d724e92-91e7-4b68-8700-34559d193ce1" />

**Before fixes**:
<img width="624" height="723" alt="image" src="https://github.com/user-attachments/assets/56d4c3f9-fc40-47da-bfb2-d2f9f68528a5" />

**After fixes**:
<img width="620" height="761" alt="Screenshot from 2026-03-19 15-52-08" src="https://github.com/user-attachments/assets/889c2b43-9621-4e87-bb22-8140183ffebf" />

